### PR TITLE
removed accidental references copied from plato

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,6 @@
 
 
 from setuptools import setup
-import plato
-import utils
-import plotting
-import general
 
 
 setup(name='artemis',


### PR DESCRIPTION
Removed references left in plato in setup.py that were accidentally left when copying code over.

Resolves issue #3.