### PR TITLE
allow unnamed experiments

### DIFF
--- a/artemis/experiments/experiment_record.py
+++ b/artemis/experiments/experiment_record.py
@@ -520,6 +520,10 @@ def get_experiment(name):
     return GLOBAL_EXPERIMENT_LIBRARY[name]
 
 
+def _kwargs_to_experiment_name(kwargs):
+    return ','.join('{}={}'.format(argname, kwargs[argname]) for argname in sorted(kwargs.keys()))
+
+
 class Experiment(object):
 
     def __init__(self, function=None, display_function = None, info = None, conclusion = None, name = None, is_root = False):
@@ -620,35 +624,52 @@ class Experiment(object):
         set_test_mode(old_test_mode)
         return exp_rec
 
-    def _create_experiment_variant(self, name, (args, kwargs), is_root):
+    def _create_experiment_variant(self, args, kwargs, is_root):
+        assert len(args) in (0, 1), "You can either provide one unnamed argument, the experiment name, or zero, in which case the experiment is named after the named argumeents.  See add_variant docstring"
+        name = args[0] if len(args) == 1 else _kwargs_to_experiment_name(kwargs)
         assert name not in self.variants, 'Variant "%s" already exists.' % (name, )
         ex = Experiment(
-            name='.'.join((self.name, name)),
-            function=partial(self, *args, **kwargs),
+            name=self.name+'.'+name,
+            function=partial(self, **kwargs),
             display_function=self.display_function,
             is_root = is_root
             )
         self.variants[name] = ex
         return ex
 
-    def add_variant(self, name, *args, **kwargs):
+    def add_variant(self, *args, **kwargs):
         """
         Add a variant to this experiment, and register it on the list of experiments.
-        :param name: The name of the root variant.
-        :param args, kwargs: Ordered/named arguments for this experiment variant
+        There are two ways you can do this:
+
+            # Name the experiment explicitely, then list the named arguments
+            my_experiment_function.add_variant('big_a', a=10000)
+            assert my_experiment_function.get_name()=='my_experiment_function.big_a'
+
+            # Allow the experiment to be named automatically, and just list the named arguments
+            my_experiment_function.add_variant(a=10000)
+            assert my_experiment_function.get_name()=='my_experiment_function.a==10000'
+
         :return: The experiment.
         """
-        return self._create_experiment_variant(name, (args, kwargs), is_root = False)
+        return self._create_experiment_variant(args, kwargs, is_root = False)
 
-    def add_root_variant(self, name, *args, **kwargs):
+    def add_root_variant(self, *args, **kwargs):
         """
         Add a variant to this experiment, but do NOT register it on the list of experiments.
-        (A root variant is indended to have variants added on top of it).
-        :param name: The name of the variant
-        :param args, kwargs: Ordered/named arguments for this experiment variant
+        There are two ways you can do this:
+
+            # Name the experiment explicitely, then list the named arguments
+            my_experiment_function.add_root_variant('big_a', a=10000)
+            assert my_experiment_function.get_name()=='my_experiment_function.big_a'
+
+            # Allow the experiment to be named automatically, and just list the named arguments
+            my_experiment_function.add_root_variant(a=10000)
+            assert my_experiment_function.get_name()=='my_experiment_function.a==10000'
+
         :return: The experiment.
         """
-        return self._create_experiment_variant(name, (args, kwargs), is_root=True)
+        return self._create_experiment_variant(args, kwargs, is_root=True)
 
     def add_note(self, note):
         """
@@ -666,6 +687,9 @@ class Experiment(object):
         :return:
         """
         return self.variants[name].get_variant(*path) if len(path)>0 else self.variants[name]
+
+    def get_unnamed_variant(self, **kwargs):
+        return self.get_variant(_kwargs_to_experiment_name(kwargs))
 
     def display_last(self):
         assert self.display_function is not None, "You have not specified a display function for experiment: %s" % (self.name, )
@@ -691,6 +715,11 @@ class Experiment(object):
                 self.run()
 
     def get_all_variants(self, include_roots = False):
+        """
+        Return a list of variants of this experiment
+        :param include_roots:
+        :return:
+        """
         variants = []
         if not self.is_root or include_roots:
             variants.append(self)
@@ -716,3 +745,19 @@ class Experiment(object):
 
     def test_all(self, **kwargs):
         self.run_all(test_mode=True, **kwargs)
+
+    def get_all_ids(self):
+        """
+        Get all identifiers of this experiment that have been run.
+        :return:
+        """
+        return get_all_experiment_ids(names = [self.name])
+
+    def clear_records(self):
+        """
+        Delete all records from this experiment
+        """
+        clear_experiments(ids = self.get_all_ids())
+
+    def get_name(self):
+        return self.name

--- a/artemis/experiments/experiment_record.py
+++ b/artemis/experiments/experiment_record.py
@@ -539,8 +539,11 @@ def experiment_testing_context():
     keep_record_by_default = True
     yield
     keep_record_by_default = old_val
-    new_ids = set(get_all_experiment_ids()).difference(ids)
-    clear_experiments(list(new_ids))
+
+    def clean_on_close():
+        new_ids = set(get_all_experiment_ids()).difference(ids)
+        clear_experiments(list(new_ids))
+    atexit.register(clean_on_close)  # We register this on exit to avoid race conditions with system commands when we open figures externally
 
 
 class Experiment(object):

--- a/artemis/experiments/test_experiment_record.py
+++ b/artemis/experiments/test_experiment_record.py
@@ -193,9 +193,13 @@ def test_variants():
         assert add_some_numbers.get_unnamed_variant(a=2, b=4).run().get_result()==6
         assert add_some_numbers.get_unnamed_variant(a=3, b=5).run().get_result()==8
 
+    experiments = add_some_numbers.get_all_variants(include_roots=True)
+    assert len(experiments)==13
+    for e in experiments:
+        e.clear_records()
+
 
 if __name__ == '__main__':
-
     set_test_mode(True)
     test_get_latest_identifier()
     test_get_latest()

--- a/artemis/experiments/test_experiment_record.py
+++ b/artemis/experiments/test_experiment_record.py
@@ -198,17 +198,14 @@ def test_variants():
         experiments = add_some_numbers.get_all_variants(include_roots=True)
         assert len(experiments)==13
 
-    experiments = add_some_numbers.get_all_variants(include_roots=True)
-    assert len(experiments) == 0  # (just test that the context cleans up)
-
 
 if __name__ == '__main__':
     set_test_mode(True)
     test_get_latest_identifier()
-    # test_get_latest()
-    # test_run_and_show()
-    # test_experiment_with()
-    # test_start_experiment()
-    # test_accessing_experiment_dir()
-    # test_saving_result()
-    # test_variants()
+    test_get_latest()
+    test_run_and_show()
+    test_experiment_with()
+    test_start_experiment()
+    test_accessing_experiment_dir()
+    test_saving_result()
+    test_variants()

--- a/artemis/experiments/ui.py
+++ b/artemis/experiments/ui.py
@@ -196,6 +196,7 @@ def browse_experiment_records(names = None, filter_text = None):
 
         if len(parts)==0:
             _warn_with_prompt("You need to specify an experiment record number!")
+            continue
 
         cmd = parts[0]
         args = parts[1:]


### PR DESCRIPTION
This allows created of unnamed experiments, which should make it easier to create, for instance, a grid of variants when doing hyperparameter optimization.