### PR TITLE
Concurrent plotting

### DIFF
--- a/artemis/plotting/plotting_server.py
+++ b/artemis/plotting/plotting_server.py
@@ -3,10 +3,15 @@ import time
 import thread
 import SimpleHTTPServer
 import SocketServer
+
+from artemis.fileman.local_dir import get_local_path
 from artemis.plotting.manage_plotting import set_show_callback, set_draw_callback
 import os
 from matplotlib import pyplot as plt
 import logging
+import atexit
+import shutil
+import uuid
 logging.basicConfig()
 ARTEMIS_LOGGER = logging.getLogger('artemis')
 
@@ -81,7 +86,12 @@ class TimedFigureSaver(object):
 
 
 def setup_web_plotting(update_period = 1.):
-    plot_directory = gettempdir()  # Temporary directory
+    plot_directory = get_local_path(relative_path="tmp/web_backend/%s/" % (str(uuid.uuid4()),),make_local_dir=True)  # Temporary directory
+    atexit.register(clean_up,plot_dir=plot_directory)
     _start_plotting_server(plot_directory=plot_directory, update_period=update_period)
     set_draw_callback(TimedFigureSaver(os.path.join(plot_directory, 'artemis_figure.png'), update_period=update_period))
     set_show_callback(TimedFigureSaver(os.path.join(plot_directory, 'artemis_figure.png'), update_period=update_period))
+
+
+def clean_up(plot_dir):
+    shutil.rmtree(plot_dir)

--- a/artemis/plotting/test_plotting_server.py
+++ b/artemis/plotting/test_plotting_server.py
@@ -1,3 +1,4 @@
+from artemis.config import get_artemis_config
 from artemis.general.test_mode import set_test_mode
 from artemis.plotting.db_plotting import dbplot
 from artemis.plotting.plotting_server import setup_web_plotting
@@ -9,12 +10,16 @@ __author__ = 'peter'
 
 
 def test_plotting_server():
-    setup_web_plotting()
 
-    for i in xrange(5):
+    config = get_artemis_config()
+    if config.get('plotting', 'backend') != 'matplotlib-web':
+        setup_web_plotting()
+
+    # for i in xrange(5):
+    while True:
         dbplot(np.random.randn(10, 10, 3), 'noise')
         dbplot(np.random.randn(20, 2), 'lines')
-        plt.pause(.01)
+        plt.pause(2.)
 
 
 if __name__ == '__main__':

--- a/artemis/plotting/test_plotting_server.py
+++ b/artemis/plotting/test_plotting_server.py
@@ -15,11 +15,11 @@ def test_plotting_server():
     if config.get('plotting', 'backend') != 'matplotlib-web':
         setup_web_plotting()
 
-    # for i in xrange(5):
-    while True:
+    for i in xrange(5):
+    # while True:
         dbplot(np.random.randn(10, 10, 3), 'noise')
         dbplot(np.random.randn(20, 2), 'lines')
-        plt.pause(2.)
+        plt.pause(0.1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Gave non-unique temporary directory for index.html. Now several processes can have their own plots concurrently without interference. Also, tmp dir is deleted at program exit. Test is updated to not run setup_web_plotting() twice in case web-backend has been set in config.