### PR TITLE
Add six to the mix and fix raw_input() and xrange() for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: python
 python:
     - 2.7
     - 3.6
-matrix:
-    allow_failures:
-        - python: 3.6
 install:
     - pip install -r requirements.txt
     - pip install flake8 pytest

--- a/artemis/examples/demo_mnist_logreg.py
+++ b/artemis/examples/demo_mnist_logreg.py
@@ -120,7 +120,7 @@ if __name__ == '__main__':
             (fig, ) = record.load_figures()
             fig.gca().set_title(ex.name)
             print(ex.name.ljust(60) \
-                  + ' '.join('{}:{}'.format(arg_name, arg_value).ljust(26) for arg_name, arg_value in args.iteritems()) \
+                  + ' '.join('{}:{}'.format(arg_name, arg_value).ljust(26) for arg_name, arg_value in args.items()) \
                   + '  ||  ' + ' '.join('{}:{}'.format(subset, score).rjust(15) for subset, score in result.items()))
         plt.show()
     else:

--- a/artemis/examples/drunkards_walk_example.py
+++ b/artemis/examples/drunkards_walk_example.py
@@ -33,7 +33,7 @@ def demo_drunkards_walk(n_steps=500, n_drunkards=5, homing_instinct = 0, n_dim=2
     for t in xrange(1, n_steps+1):
         drunkards[t] = drunkards[t-1]*(1-homing_instinct) + rng.randn(n_drunkards, n_dim)
         if t%100==0:
-            print 'Status at step {}: Mean: {}, STD: {}'.format(t, drunkards[t].mean(), drunkards[t].std())
+            print ('Status at step {}: Mean: {}, STD: {}'.format(t, drunkards[t].mean(), drunkards[t].std()))
     return drunkards
 
 

--- a/artemis/examples/drunkards_walk_example.py
+++ b/artemis/examples/drunkards_walk_example.py
@@ -1,6 +1,7 @@
 import numpy as np
 from artemis.experiments import ExperimentFunction
 from matplotlib import pyplot as plt
+from six.moves import xrange
 
 
 def display_drunkards_walk(drunkards):

--- a/artemis/examples/drunkards_walk_example.py
+++ b/artemis/examples/drunkards_walk_example.py
@@ -14,7 +14,7 @@ def display_drunkards_walk(drunkards):
 
 def compare_drunkards_walk(dict_of_drunkards):
     plot_handles = []
-    for i, (exp_name, drunkards) in enumerate(dict_of_drunkards.iteritems()):
+    for i, (exp_name, drunkards) in enumerate(dict_of_drunkards.items()):
         plot_handles.append(plt.plot(drunkards[:, :, 0], drunkards[:, :, 1], color='C{}'.format(i)))
     plt.grid()
     plt.xlabel('$\Delta$ Longitude (arcseconds)')

--- a/artemis/experiments/demo_experiments.py
+++ b/artemis/experiments/demo_experiments.py
@@ -1,6 +1,7 @@
 import numpy as np
 from artemis.experiments import experiment_function
 from matplotlib import pyplot as plt
+from six.moves import xrange
 
 __author__ = 'peter'
 

--- a/artemis/experiments/experiment_management.py
+++ b/artemis/experiments/experiment_management.py
@@ -4,6 +4,7 @@ import traceback
 from collections import OrderedDict
 from functools import partial
 from importlib import import_module
+from six import string_types
 from six.moves import reduce, xrange
 
 from artemis.experiments.experiment_record import (load_experiment_record, ExpInfoFields,
@@ -27,7 +28,7 @@ def pull_experiments(user, ip, experiment_names, include_variants=True):
     import pexpect
     import sys
 
-    if isinstance(experiment_names, basestring):
+    if isinstance(experiment_names, string_types):
         experiment_names = [experiment_names]
 
     inclusions = ' '.join("--include='**/*-{exp_name}{variants}/*'".format(exp_name=exp_name, variants = '*' if include_variants else '') for exp_name in experiment_names)
@@ -61,9 +62,9 @@ def load_lastest_experiment_results(experiments, error_if_no_result = True):
     results = OrderedDict()
     for ex in experiments:
 
-        ex = load_experiment(ex) if isinstance(ex, basestring) else ex
+        ex = load_experiment(ex) if isinstance(ex, string_types) else ex
 
-        name = experiments[ex.get_id()] if isinstance(experiments, dict) else ex if isinstance(ex, basestring) else ex.get_id()
+        name = experiments[ex.get_id()] if isinstance(experiments, dict) else ex if isinstance(ex, string_types) else ex.get_id()
 
         record = ex.get_latest_record(err_if_none=error_if_no_result, only_completed=True)
         if record is None:

--- a/artemis/experiments/experiment_management.py
+++ b/artemis/experiments/experiment_management.py
@@ -165,7 +165,7 @@ def _filter_records(user_range, exp_record_dict):
     if '&' in user_range:
         return reduce(lambda a, b: _bitwise('and', a, b), [_filter_records(subrange, exp_record_dict) for subrange in user_range.split('&')])
     number_range = interpret_numbers(user_range)
-    keys = exp_record_dict.keys()
+    keys = list(exp_record_dict.keys())
     if number_range is not None:
         for i in number_range:
             base[keys[i]] = [True]*len(base[keys[i]])

--- a/artemis/experiments/experiment_management.py
+++ b/artemis/experiments/experiment_management.py
@@ -4,9 +4,10 @@ import traceback
 from collections import OrderedDict
 from functools import partial
 from importlib import import_module
+from six.moves import xrange
 
-from artemis.experiments.experiment_record import load_experiment_record, ExpInfoFields, \
-    ExpStatusOptions, ARTEMIS_LOGGER, record_id_to_experiment_id
+from artemis.experiments.experiment_record import (load_experiment_record, ExpInfoFields,
+    ExpStatusOptions, ARTEMIS_LOGGER, record_id_to_experiment_id)
 from artemis.experiments.experiments import load_experiment, get_global_experiment_library
 from artemis.fileman.config_files import get_home_dir
 from artemis.general.hashing import compute_fixed_hash

--- a/artemis/experiments/experiment_management.py
+++ b/artemis/experiments/experiment_management.py
@@ -174,20 +174,20 @@ def _filter_records(user_range, exp_record_dict):
         for exp_number, rec_number in exp_rec_pairs:
             base[keys[exp_number]][rec_number] = True
     elif user_range == 'old':
-        for k, v in base.iteritems():
+        for k, v in base.items():
             base[k] = ([True]*(len(v)-1)+[False]) if len(v)>0 else []
     elif user_range == 'unfinished':
-        for k, v in base.iteritems():
+        for k, v in base.items():
             base[k] = [load_experiment_record(rec_id).info.get_field(ExpInfoFields.STATUS) != ExpStatusOptions.FINISHED for rec_id in exp_record_dict[k]]
         # filtered_dict = OrderedDict((exp_id, [rec_id for rec_id in records if load_experiment_record(rec_id).info.get_field(ExpInfoFields.STATUS) != ExpStatusOptions.FINISHED]) for exp_id, records in exp_record_dict.iteritems())
     elif user_range == 'invalid':
-        for k, v in base.iteritems():
+        for k, v in base.items():
             base[k] = [load_experiment_record(rec_id).args_valid() is False for rec_id in exp_record_dict[k]]
     elif user_range == 'all':
-        for k, v in base.iteritems():
+        for k, v in base.items():
             base[k] = [True]*len(v)
     elif user_range == 'errors':
-        for k, v in base.iteritems():
+        for k, v in base.items():
             base[k] = [load_experiment_record(rec_id).info.get_field(ExpInfoFields.STATUS)==ExpStatusOptions.ERROR for rec_id in exp_record_dict[k]]
     else:
         raise Exception("Don't know how to interpret subset '{}'".format(user_range))

--- a/artemis/experiments/experiment_management.py
+++ b/artemis/experiments/experiment_management.py
@@ -155,7 +155,7 @@ def _filter_records(user_range, exp_record_dict):
             filter_set_3[k] = [(a or b) if op=='or' else (a and b) for a, b in izip_equal(filter_set_1[k], filter_set_2[k])]
         return filter_set_3
 
-    base = OrderedDict((k, [False]*len(v)) for k, v in exp_record_dict.iteritems())
+    base = OrderedDict((k, [False]*len(v)) for k, v in exp_record_dict.items())
     if user_range in exp_record_dict:  # User just lists an experiment
         base[user_range] = [True]*len(base[user_range])
         return base

--- a/artemis/experiments/experiment_management.py
+++ b/artemis/experiments/experiment_management.py
@@ -4,7 +4,7 @@ import traceback
 from collections import OrderedDict
 from functools import partial
 from importlib import import_module
-from six.moves import xrange
+from six.moves import reduce, xrange
 
 from artemis.experiments.experiment_record import (load_experiment_record, ExpInfoFields,
     ExpStatusOptions, ARTEMIS_LOGGER, record_id_to_experiment_id)

--- a/artemis/experiments/experiment_record.py
+++ b/artemis/experiments/experiment_record.py
@@ -7,7 +7,7 @@ import sys
 import tempfile
 import traceback
 from collections import OrderedDict
-from contextlib import contextmanager, nested
+from contextlib import contextmanager
 from datetime import datetime
 
 from artemis.config import get_artemis_config_value
@@ -15,6 +15,7 @@ from artemis.fileman.local_dir import format_filename, make_file_dir, get_artemi
 from artemis.fileman.persistent_ordered_dict import PersistentOrderedDict
 from artemis.general.display import CaptureStdOut
 from artemis.general.hashing import compute_fixed_hash
+from artemis.general.should_be_builtins import nested
 from artemis.general.test_mode import is_test_mode
 
 try:

--- a/artemis/experiments/experiment_record.py
+++ b/artemis/experiments/experiment_record.py
@@ -223,7 +223,7 @@ class ExperimentRecord(object):
         """
         result_loc = os.path.join(self._experiment_directory, 'result.pkl')
         if os.path.exists(result_loc):
-            with open(result_loc) as f:
+            with open(result_loc, 'rb') as f:
                 result = pickle.load(f)
             return result
         elif err_if_none:
@@ -286,7 +286,7 @@ class ExperimentRecord(object):
         figs = []
         for fig_path in locs:
             assert fig_path.endswith('.pkl'), 'Figure {} was not saved as a pickle, so it cannot be reloaded.'.format(fig_path)
-            with open(fig_path) as f:
+            with open(fig_path, 'rb') as f:
                 figs.append(pickle.load(f))
         return figs
 

--- a/artemis/experiments/experiment_record.py
+++ b/artemis/experiments/experiment_record.py
@@ -96,10 +96,10 @@ class ExperimentRecordInfo(object):
     def get_text(self):
         if ExpInfoFields.VERSION not in self.persistent_obj:  # Old version... we must adapt
             return '\n'.join(
-                '{}: {}'.format(key, self.get_field_text(key)) for key, value in self.persistent_obj.iteritems())
+                '{}: {}'.format(key, self.get_field_text(key)) for key, value in self.persistent_obj.items())
         else:
             return '\n'.join(
-                '{}: {}'.format(key.value, self.get_field_text(key)) for key, value in self.persistent_obj.iteritems())
+                '{}: {}'.format(key.value, self.get_field_text(key)) for key, value in self.persistent_obj.items())
 
     def get_field_text(self, field, replacement_if_none=''):
         assert field in ExpInfoFields, 'Field must be a member of ExperimentRecordInfo.FIELDS'

--- a/artemis/experiments/experiment_record.py
+++ b/artemis/experiments/experiment_record.py
@@ -234,7 +234,7 @@ class ExperimentRecord(object):
     def save_result(self, result):
         file_path = get_local_experiment_path(os.path.join(self._experiment_directory, 'result.pkl'))
         make_file_dir(file_path)
-        with open(file_path, 'w') as f:
+        with open(file_path, 'wb') as f:
             pickle.dump(result, f, protocol=2)
             print('Saving Result for Experiment "%s"' % (self.get_id(),))
 

--- a/artemis/experiments/experiment_record_view.py
+++ b/artemis/experiments/experiment_record_view.py
@@ -93,7 +93,7 @@ def get_record_invalid_arg_string(record, recursive=True):
                 if recursive:
                     last_run_args = OrderedDict(flatten_struct(last_run_args, first_dict_is_namespace=True))
                     current_args = OrderedDict(flatten_struct(current_args, first_dict_is_namespace=True))
-                last_arg_str, this_arg_str = [['{}:{}'.format(k, v) for k, v in argdict.iteritems()] for argdict in (last_run_args, current_args)]
+                last_arg_str, this_arg_str = [['{}:{}'.format(k, v) for k, v in argdict.items()] for argdict in (last_run_args, current_args)]
                 common, (old_args, new_args) = separate_common_items([last_arg_str, this_arg_str])
                 notes = "No: Args changed!: {{{}}}->{{{}}}".format(','.join(old_args), ','.join(new_args))
             elif validity is None:
@@ -241,7 +241,7 @@ def find_experiment(*search_terms):
     :return:
     """
     global_lib = get_global_experiment_library()
-    found_experiments = OrderedDict((name, ex) for name, ex in global_lib.iteritems() if all(re.search(term, name) for term in search_terms))
+    found_experiments = OrderedDict((name, ex) for name, ex in global_lib.items() if all(re.search(term, name) for term in search_terms))
     if len(found_experiments)==0:
         raise Exception("None of the {} experiments matched the search: '{}'".format(len(global_lib), search_terms))
     elif len(found_experiments)>1:

--- a/artemis/experiments/experiment_record_view.py
+++ b/artemis/experiments/experiment_record_view.py
@@ -12,6 +12,7 @@ from artemis.general.display import deepstr, truncate_string, hold_numpy_printop
 from artemis.general.nested_structures import flatten_struct
 from artemis.general.should_be_builtins import separate_common_items, all_equal, bad_value, izip_equal
 from artemis.general.tables import build_table
+from six import string_types
 
 
 def get_record_result_string(record, func='deep', truncate_to = None, array_print_threshold=8, array_float_format='.3g', oneline=False):
@@ -22,7 +23,7 @@ def get_record_result_string(record, func='deep', truncate_to = None, array_prin
     :return:
     """
     with hold_numpy_printoptions(threshold = array_print_threshold, formatter={'float': lambda x: '{{:{}}}'.format(array_float_format).format(x)}):
-        if isinstance(func, basestring):
+        if isinstance(func, string_types):
             func = {
                 'deep': deepstr,
                 'str': str,
@@ -117,7 +118,7 @@ def get_oneline_result_string(record, truncate_to=None, array_float_format='.3g'
     :param array_print_threshold:
     :return: A string with no newlines briefly describing the result of the record.
     """
-    if isinstance(record, basestring):
+    if isinstance(record, string_types):
         record = load_experiment_record(record)
     if not is_experiment_loadable(record.get_experiment_id()):
         one_liner_function=str

--- a/artemis/experiments/experiments.py
+++ b/artemis/experiments/experiments.py
@@ -113,7 +113,7 @@ class Experiment(object):
                 exp_rec.info.set_field(ExpInfoFields.NAME, self.name)
                 exp_rec.info.set_field(ExpInfoFields.ID, exp_rec.get_id())
                 exp_rec.info.set_field(ExpInfoFields.DIR, exp_rec.get_dir())
-                exp_rec.info.set_field(EIF.ARGS, self.get_args().items())
+                exp_rec.info.set_field(EIF.ARGS, list(self.get_args().items()))
                 root_function = self.get_root_function()
                 exp_rec.info.set_field(EIF.FUNCTION, root_function.__name__)
                 exp_rec.info.set_field(EIF.TIMESTAMP, str(date))

--- a/artemis/experiments/experiments.py
+++ b/artemis/experiments/experiments.py
@@ -13,7 +13,7 @@ from six import string_types
 from artemis.experiments.experiment_record import ARTEMIS_LOGGER, \
     ExpInfoFields, record_experiment, ExpStatusOptions, experiment_id_to_record_ids, load_experiment_record, \
     get_all_record_ids, clear_experiment_records
-from artemis.general.functional import infer_derived_arg_values, get_partial_chain
+from artemis.general.functional import infer_derived_arg_values, get_partial_root
 from artemis.general.test_mode import is_test_mode, set_test_mode
 
 
@@ -70,7 +70,7 @@ class Experiment(object):
         return infer_derived_arg_values(self.function)
 
     def get_root_function(self):
-        return get_partial_chain(self.function)[0]
+        return get_partial_root(self.function)
 
     def run(self, print_to_console=True, show_figs=None, test_mode=None, keep_record=None, raise_exceptions=True,
             display_results=True, **experiment_record_kwargs):

--- a/artemis/experiments/experiments.py
+++ b/artemis/experiments/experiments.py
@@ -290,7 +290,7 @@ class Experiment(object):
         variants = []
         if include_self and (not self.is_root or include_roots):
             variants.append(self)
-        for name, v in self.variants.iteritems():
+        for name, v in self.variants.items():
             variants += v.get_all_variants(include_roots=include_roots, include_self=True)
         return variants
 

--- a/artemis/experiments/experiments.py
+++ b/artemis/experiments/experiments.py
@@ -7,6 +7,9 @@ from datetime import datetime
 from functools import partial
 from getpass import getuser
 from uuid import getnode
+
+from six import string_types
+
 from artemis.experiments.experiment_record import ARTEMIS_LOGGER, \
     ExpInfoFields, record_experiment, ExpStatusOptions, experiment_id_to_record_ids, load_experiment_record, \
     get_all_record_ids, clear_experiment_records
@@ -395,7 +398,7 @@ def load_experiment(experiment_id):
 
 
 def is_experiment_loadable(experiment_id):
-    assert isinstance(experiment_id, basestring), 'Expected a string for experiment_id, not {}'.format(experiment_id)
+    assert isinstance(experiment_id, string_types), 'Expected a string for experiment_id, not {}'.format(experiment_id)
     return experiment_id in _GLOBAL_EXPERIMENT_LIBRARY
 
 

--- a/artemis/experiments/test_experiment_record.py
+++ b/artemis/experiments/test_experiment_record.py
@@ -422,7 +422,7 @@ def test_current_experiment_access_functions():
 
             assert os.path.exists(os.path.join(loc, 'somefile.pkl'))
 
-            with open_in_record_dir('somefile.pkl') as f:
+            with open_in_record_dir('somefile.pkl', 'rb') as f:
                 assert pickle.load(f) == [1, 2, 3]
 
             exp = rec.get_experiment()

--- a/artemis/experiments/test_experiment_record.py
+++ b/artemis/experiments/test_experiment_record.py
@@ -8,6 +8,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pickle
 import pytest
+from six.moves import xrange
 
 from artemis.experiments.decorators import experiment_function
 from artemis.experiments.deprecated import start_experiment, end_current_experiment

--- a/artemis/experiments/test_experiment_record.py
+++ b/artemis/experiments/test_experiment_record.py
@@ -298,7 +298,7 @@ def test_parallel_run_errors():
             run_multiple_experiments(variants, parallel=True, raise_exceptions=True)
         print("^^^ Dont't worry, the above is not actually an error, we were just asserting that we caught the error.")
 
-        assert err.value.message == 'nononono'
+        assert str(err.value) == 'nononono'
 
 
 def test_invalid_arg_detection():

--- a/artemis/experiments/test_experiment_record.py
+++ b/artemis/experiments/test_experiment_record.py
@@ -417,7 +417,7 @@ def test_current_experiment_access_functions():
             assert os.path.isdir(loc)
             assert loc.endswith(record_id)
 
-            with open_in_record_dir('somefile.pkl', 'w') as f:
+            with open_in_record_dir('somefile.pkl', 'wb') as f:
                 pickle.dump([1, 2, 3], f, protocol=pickle.HIGHEST_PROTOCOL)
 
             assert os.path.exists(os.path.join(loc, 'somefile.pkl'))

--- a/artemis/experiments/ui.py
+++ b/artemis/experiments/ui.py
@@ -283,7 +283,7 @@ experiment records.  You can specify records in the following ways:
                     raise
                 return '<Display Error>'
 
-        for i, (exp_id, record_ids) in enumerate(exp_record_dict.iteritems()):
+        for i, (exp_id, record_ids) in enumerate(exp_record_dict.items()):
             if len(record_ids)==0:
                 if exp_id in exp_record_dict:
                     rows.append([str(i), '', exp_id, '<No Records>'] + ['-']*(len(headers)-4))

--- a/artemis/experiments/ui.py
+++ b/artemis/experiments/ui.py
@@ -1,15 +1,16 @@
 import shlex
 from collections import OrderedDict
+from six.moves import input
 
 from tabulate import tabulate
 
-from artemis.experiments.experiment_management import pull_experiments, select_experiments, select_experiment_records, \
-    select_experiment_records_from_list, interpret_numbers, run_multiple_experiments
-from artemis.experiments.experiment_record import get_all_record_ids, clear_experiment_records, \
-    experiment_id_to_record_ids, load_experiment_record, ExpInfoFields
-from artemis.experiments.experiment_record_view import get_record_full_string, get_record_invalid_arg_string, \
-    print_experiment_record_argtable, compare_experiment_results, show_experiment_records, get_oneline_result_string, \
-    display_experiment_record
+from artemis.experiments.experiment_management import (pull_experiments, select_experiments, select_experiment_records,
+    select_experiment_records_from_list, interpret_numbers, run_multiple_experiments)
+from artemis.experiments.experiment_record import (get_all_record_ids, clear_experiment_records,
+    experiment_id_to_record_ids, load_experiment_record, ExpInfoFields)
+from artemis.experiments.experiment_record_view import (get_record_full_string, get_record_invalid_arg_string,
+    print_experiment_record_argtable, compare_experiment_results, show_experiment_records, get_oneline_result_string,
+    display_experiment_record)
 from artemis.experiments.experiments import load_experiment, get_global_experiment_library
 from artemis.fileman.disk_memoize import memoize_to_disk_with_settings
 from artemis.general.display import IndentPrint, side_by_side
@@ -17,17 +18,17 @@ from artemis.general.mymath import levenshtein_distance
 from artemis.general.should_be_builtins import all_equal
 
 try:
-    import readline  # Makes raw_input behave like interactive shell.
+    import readline  # Makes input() behave like interactive shell.
     # http://stackoverflow.com/questions/15416054/command-line-in-python-with-history
 except:
     pass  # readline not available
 
 
 def _warn_with_prompt(message= None, prompt = 'Press Enter to continue or q then Enter to quit', use_prompt=True):
-    if message is not None:
+    if message:
         print(message)
     if use_prompt:
-        out = raw_input('({}) >> '.format(prompt))
+        out = input('({}) >> '.format(prompt)).strip().lower()
         if out=='q':
             quit()
         else:

--- a/artemis/experiments/ui.py
+++ b/artemis/experiments/ui.py
@@ -213,9 +213,9 @@ experiment records.  You can specify records in the following ways:
                 print('[Filtered with "{}" to show {}/{} experiments]'.format(self._filter, len(self.exp_record_dict), len(all_experiments)))
             print('-----------------------------------------------------')
             if command is None:
-                user_input = raw_input('Enter command or experiment # to run (h for help) >> ').lstrip(' ').rstrip(' ')
+                user_input = input('Enter command or experiment # to run (h for help) >> ').strip()
             else:
-                user_input=command
+                user_input = command
                 command = None
             with IndentPrint():
                 try:
@@ -240,16 +240,16 @@ experiment records.  You can specify records in the following ways:
                         min_distance = min(edit_distances)
                         closest = func_dict.keys()[edit_distances.index(min_distance)]
                         suggestion = ' Did you mean "{}"?.  '.format(closest) if min_distance<=2 else ''
-                        response = raw_input('Unrecognised command: "{}". {}Type "h" for help or Enter to continue. >'.format(cmd, suggestion, closest))
-                        if response.lower()=='h':
+                        response = input('Unrecognised command: "{}". {}Type "h" for help or Enter to continue. >'.format(cmd, suggestion, closest))
+                        if response.strip().lower()=='h':
                             self.help()
                         out = None
                     if out is self.QUIT or self.close_after:
                         break
                 except Exception as name:
                     if self.catch_errors:
-                        res = raw_input('%s: %s\nEnter "e" to view the stacktrace, or anything else to continue.' % (name.__class__.__name__, name.message))
-                        if res == 'e':
+                        res = input('%s: %s\nEnter "e" to view the stacktrace, or anything else to continue.' % (name.__class__.__name__, name.message))
+                        if res.strip().lower() == 'e':
                             raise
                     else:
                         raise
@@ -364,8 +364,8 @@ experiment records.  You can specify records in the following ways:
         print('{} out of {} Records will be deleted.'.format(len(records), sum(len(recs) for recs in self.exp_record_dict.values())))
         with IndentPrint():
             print(ExperimentRecordBrowser.get_record_table(records, ))
-        response = raw_input('Type "yes" to continue. >')
-        if response.lower() == 'yes':
+        response = input('Type "yes" to continue. >').strip().lower()
+        if response == 'yes':
             clear_experiment_records([record.get_id() for record in records])
             print('Records deleted.')
         else:
@@ -533,7 +533,7 @@ class ExperimentRecordBrowser(object):
 
             if self.experiment_names is not None or len(self.filters) != 0:
                 print('Not showing all experiments.  Type "showall" to see all experiments, or "viewfilters" to view current filters.')
-            user_input = raw_input('Enter Command (show # to show and experiment, or h for help) >>')
+            user_input = input('Enter Command (show # to show and experiment, or h for help) >>').strip()
             parts = shlex.split(user_input)
             if len(parts)==0:
                 print("You need to specify an command.  Press h for help.")
@@ -549,8 +549,8 @@ class ExperimentRecordBrowser(object):
                     if return_val==self.QUIT:
                         break
             except Exception as e:
-                res = raw_input('%s: %s\nEnter "e" to view the stacktrace, or anything else to continue.' % (e.__class__.__name__, e.message))
-                if res == 'e':
+                res = input('%s: %s\nEnter "e" to view the stacktrace, or anything else to continue.' % (e.__class__.__name__, e.message))
+                if res.strip().lower() == 'e':
                     raise
 
     def _select_records(self, user_range):
@@ -600,8 +600,8 @@ class ExperimentRecordBrowser(object):
         ids = self._select_records(user_range)
         print('We will delete the following experiments:')
         print(self.get_record_table(ids))
-        conf = raw_input("Going to clear {} of {} experiment records shown above.  Enter 'yes' to confirm: ".format(len(ids), len(self.record_ids)))
-        if conf=='yes':
+        conf = input("Going to clear {} of {} experiment records shown above.  Enter 'yes' to confirm: ".format(len(ids), len(self.record_ids)))
+        if conf.strip().lower() == 'yes':
             clear_experiment_records(ids=ids)
         else:
             _warn_with_prompt("Did not delete experiments")

--- a/artemis/fileman/config_files.py
+++ b/artemis/fileman/config_files.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from ConfigParser import NoSectionError, NoOptionError, ConfigParser
+from six.moves.configparser import NoSectionError, NoOptionError, ConfigParser
 
 __author__ = 'peter'
 

--- a/artemis/fileman/disk_memoize.py
+++ b/artemis/fileman/disk_memoize.py
@@ -78,7 +78,7 @@ def memoize_to_disk(fcn, local_cache = False, disable_on_tests=True, use_cpickle
                         LOGGER.info('Reading disk-memo from local cache for function %s' % (fcn.__name__, ))
                     return cached_local_results[filepath]
             if os.path.exists(filepath):
-                with open(filepath) as f:
+                with open(filepath, 'rb') as f:
                     try:
                         if not suppress_info:
                             LOGGER.info('Reading memo for function %s' % (fcn.__name__, ))

--- a/artemis/fileman/disk_memoize.py
+++ b/artemis/fileman/disk_memoize.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from functools import partial
+from six.moves import input
 from artemis.fileman.local_dir import get_artemis_data_path, make_file_dir
 from artemis.general.functional import infer_arg_values
 from artemis.general.hashing import compute_fixed_hash
@@ -219,7 +220,7 @@ class DisableMemos(object):
 
 if __name__ == '__main__':
 
-    cmd = raw_input('Type "clearall" to clear all memos: ')
+    cmd = input('Type "clearall" to clear all memos: ').strip().lower()
 
     if cmd == 'clearall':
         clear_all_memos()

--- a/artemis/fileman/disk_memoize.py
+++ b/artemis/fileman/disk_memoize.py
@@ -103,7 +103,7 @@ def memoize_to_disk(fcn, local_cache = False, disable_on_tests=True, use_cpickle
             if result_computed:  # Result was computed, so write it down
                 filepath = get_function_hash_filename(fcn, full_args)
                 make_file_dir(filepath)
-                with open(filepath, 'w') as f:
+                with open(filepath, 'wb') as f:
                     if not suppress_info:
                         LOGGER.info('Writing disk-memo for function %s' % (fcn.__name__, ))
                     pickle.dump(result, f, protocol=2)

--- a/artemis/fileman/file_getter.py
+++ b/artemis/fileman/file_getter.py
@@ -1,6 +1,6 @@
 import hashlib
 import tempfile
-from StringIO import StringIO
+from six.moves import StringIO
 import gzip
 import tarfile
 from zipfile import ZipFile

--- a/artemis/fileman/file_getter.py
+++ b/artemis/fileman/file_getter.py
@@ -85,9 +85,10 @@ def get_archive(relative_path, url, force_extract=False, archive_type = None, fo
             elif url.endswith('.zip'):
                 archive_type = '.zip'
             else:
-                info = response.info()
+                # info = response.info()
                 try:
-                    header = next(x for x in info.headers if x.startswith('Content-Disposition'))
+                    # header = next(x for x in info.headers if x.startswith('Content-Disposition'))
+                    header = response.headers['content-disposition']
                     original_file_name = next(x for x in header.split(';') if x.startswith('filename')).split('=')[-1].lstrip('"\'').rstrip('"\'')
                     archive_type = '.tar.gz' if original_file_name.endswith('.tar.gz') else '.zip' if original_file_name.endswith('.zip') else \
                         bad_value(original_file_name, 'Filename "%s" does not end with a familiar zip extension like .zip or .tar.gz' % (original_file_name, ))

--- a/artemis/fileman/file_getter.py
+++ b/artemis/fileman/file_getter.py
@@ -123,7 +123,7 @@ def get_file_and_cache(url, data_transformation = None, enable_cache_write = Tru
 
     if enable_cache_read or enable_cache_write:
         hasher = hashlib.md5()
-        hasher.update(url)
+        hasher.update(url.encode('utf-8'))
         code = hasher.hexdigest()
         local_cache_path = os.path.join(get_artemis_data_path('caches'), code + ext)
 

--- a/artemis/fileman/file_getter.py
+++ b/artemis/fileman/file_getter.py
@@ -1,6 +1,5 @@
 import hashlib
 import tempfile
-import urllib2
 from StringIO import StringIO
 import gzip
 import tarfile
@@ -9,6 +8,7 @@ from artemis.fileman.local_dir import get_artemis_data_path, make_dir, make_file
 from artemis.general.should_be_builtins import bad_value
 import shutil
 import os
+from six.moves.urllib.request import urlopen
 
 __author__ = 'peter'
 
@@ -29,7 +29,7 @@ def get_file(relative_name, url = None, data_transformation = None):
         assert url is not None, "No local copy of '%s' was found, and you didn't provide a URL to fetch it from" % (full_filename, )
 
         print('Downloading file from url: "%s"...' % (url, ))
-        response = urllib2.urlopen(url)
+        response = urlopen(url)
         data = response.read()
         print('...Done.')
 
@@ -76,7 +76,7 @@ def get_archive(relative_path, url, force_extract=False, archive_type = None, fo
 
     if not os.path.exists(local_folder_path) or force_download:  # If the folder does not exist, download zip and extract.
         # (We also check force download here to avoid a race condition)
-        response = urllib2.urlopen(url)
+        response = urlopen(url)
 
         # Need to infer
         if archive_type is None:

--- a/artemis/fileman/file_getter.py
+++ b/artemis/fileman/file_getter.py
@@ -36,7 +36,7 @@ def get_file(relative_name, url = None, data_transformation = None):
         if data_transformation is not None:
             print('Processing downloaded data...')
             data = data_transformation(data)
-        with open(full_filename, 'w') as f:
+        with open(full_filename, 'wb') as f:
             f.write(data)
     return full_filename
 
@@ -99,7 +99,7 @@ def get_archive(relative_path, url, force_extract=False, archive_type = None, fo
 
         local_zip_path = local_folder_path + archive_type
         make_file_dir(local_zip_path)
-        with open(local_zip_path, 'w') as f:
+        with open(local_zip_path, 'wb') as f:
             f.write(data)
 
         force_extract = True

--- a/artemis/fileman/local_dir.py
+++ b/artemis/fileman/local_dir.py
@@ -2,6 +2,7 @@ import datetime
 from artemis.fileman.config_files import get_config_value
 from artemis.config import get_artemis_config_value
 import os
+from six.moves import xrange
 
 __author__ = 'peter'
 

--- a/artemis/fileman/persistent_ordered_dict.py
+++ b/artemis/fileman/persistent_ordered_dict.py
@@ -39,7 +39,7 @@ class PersistentOrderedDict(OrderedDict):
 
     def close(self):
         with open(self.file_path, 'w') as f:
-            pickle.dump(self.items(), f, protocol=self.pickle_protocol)
+            pickle.dump(list(self.items()), f, protocol=self.pickle_protocol)
 
     def __exit__(self, thing1, thing2, thing3):
         self.close()

--- a/artemis/fileman/persistent_ordered_dict.py
+++ b/artemis/fileman/persistent_ordered_dict.py
@@ -3,6 +3,8 @@ from collections import OrderedDict
 import pickle
 import os
 
+from artemis.fileman.local_dir import make_file_dir
+
 
 class PersistentOrderedDict(OrderedDict):
     """
@@ -38,6 +40,7 @@ class PersistentOrderedDict(OrderedDict):
         return self
 
     def close(self):
+        make_file_dir(self.file_path)
         with open(self.file_path, 'wb') as f:
             pickle.dump(list(self.items()), f, protocol=self.pickle_protocol)
 

--- a/artemis/fileman/persistent_ordered_dict.py
+++ b/artemis/fileman/persistent_ordered_dict.py
@@ -38,7 +38,7 @@ class PersistentOrderedDict(OrderedDict):
         return self
 
     def close(self):
-        with open(self.file_path, 'w') as f:
+        with open(self.file_path, 'wb') as f:
             pickle.dump(list(self.items()), f, protocol=self.pickle_protocol)
 
     def __exit__(self, thing1, thing2, thing3):

--- a/artemis/fileman/smart_io.py
+++ b/artemis/fileman/smart_io.py
@@ -35,7 +35,7 @@ def smart_save(obj, relative_path, remove_file_after = False):
     with smart_file(relative_path, make_dir=True) as local_path:
         print('Saved object <%s at %s> to file: "%s"' % (obj.__class__.__name__, hex(id(object)), local_path))
         if ext=='.pkl':
-            with open(local_path, 'w') as f:
+            with open(local_path, 'wb') as f:
                 pickle.dump(obj, f, protocol=pickle.HIGHEST_PROTOCOL)
         elif ext in _IMAGE_EXTENSIONS:
             _save_image(obj, local_path)

--- a/artemis/fileman/test_config_files.py
+++ b/artemis/fileman/test_config_files.py
@@ -1,4 +1,4 @@
-from ConfigParser import NoSectionError, NoOptionError
+from six.moves.configparser import NoSectionError, NoOptionError
 from pytest import raises
 from artemis.fileman.config_files import get_config_path, get_config_value, set_non_persistent_config_value
 import os

--- a/artemis/fileman/test_disk_memoize.py
+++ b/artemis/fileman/test_disk_memoize.py
@@ -7,6 +7,7 @@ from pytest import raises
 
 __author__ = 'peter'
 
+
 @memoize_to_disk_test
 def compute_slow_thing(a, b, c):
     call_time = time.time()

--- a/artemis/fileman/test_file_getter.py
+++ b/artemis/fileman/test_file_getter.py
@@ -2,6 +2,8 @@ import shutil
 from artemis.fileman.file_getter import get_file_in_archive
 from artemis.fileman.local_dir import get_artemis_data_path
 import os
+from six.moves import xrange
+
 __author__ = 'peter'
 
 

--- a/artemis/fileman/test_file_getter.py
+++ b/artemis/fileman/test_file_getter.py
@@ -4,6 +4,7 @@ from artemis.fileman.local_dir import get_artemis_data_path
 import os
 from six.moves import xrange
 
+
 __author__ = 'peter'
 
 

--- a/artemis/fileman/test_persistent_ordered_dict.py
+++ b/artemis/fileman/test_persistent_ordered_dict.py
@@ -11,7 +11,7 @@ def test_persistent_ordered_dict():
         os.remove(file_path)
 
     with PersistentOrderedDict(file_path) as pod:
-        assert pod.items() == []
+        assert list(pod.items()) == []
         pod['a'] = [1, 2, 3]
         pod['b'] = [4, 5, 6]
         pod['c'] = [7, 8]

--- a/artemis/fileman/test_persistent_ordered_dict.py
+++ b/artemis/fileman/test_persistent_ordered_dict.py
@@ -18,11 +18,11 @@ def test_persistent_ordered_dict():
     pod['d'] = [9, 10]  # Should not be recorded
 
     with PersistentOrderedDict(file_path) as pod:
-        assert pod.items() == [('a', [1, 2, 3]), ('b', [4, 5, 6]), ('c', [7, 8])]
+        assert list(pod.items()) == [('a', [1, 2, 3]), ('b', [4, 5, 6]), ('c', [7, 8])]
         pod['e']=11
 
     with PersistentOrderedDict(file_path) as pod:
-        assert pod.items() == [('a', [1, 2, 3]), ('b', [4, 5, 6]), ('c', [7, 8]), ('e', 11)]
+        assert list(pod.items()) == [('a', [1, 2, 3]), ('b', [4, 5, 6]), ('c', [7, 8]), ('e', 11)]
 
 
 if __name__ == '__main__':

--- a/artemis/general/dict_ops.py
+++ b/artemis/general/dict_ops.py
@@ -40,4 +40,4 @@ def merge_dicts(*dicts):
     :param dicts: dictionaries.
     :return: A merged dictionary.
     """
-    return dict(sum([d.items() for d in dicts], []))
+    return dict((k, v) for d in dicts for k, v in d.items())

--- a/artemis/general/display.py
+++ b/artemis/general/display.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 from artemis.fileman.local_dir import make_file_dir
 from artemis.general.should_be_builtins import izip_equal
 import numpy as np
+from six import string_types
 from six.moves import xrange
 
 __author__ = 'peter'
@@ -281,7 +282,7 @@ def assert_things_are_printed(things, min_len=None):
     :return:
     """
 
-    if isinstance(things, basestring):
+    if isinstance(things, string_types):
         things = [things]
 
     with CaptureStdOut() as cap:

--- a/artemis/general/display.py
+++ b/artemis/general/display.py
@@ -7,7 +7,7 @@ from artemis.fileman.local_dir import make_file_dir
 from artemis.general.should_be_builtins import izip_equal
 import numpy as np
 from six import string_types
-from six.moves import xrange
+from six.moves import xrange, StringIO
 
 __author__ = 'peter'
 

--- a/artemis/general/display.py
+++ b/artemis/general/display.py
@@ -1,8 +1,6 @@
 import sys
 import textwrap
-from StringIO import StringIO
 from contextlib import contextmanager
-
 from artemis.fileman.local_dir import make_file_dir
 from artemis.general.should_be_builtins import izip_equal
 import numpy as np

--- a/artemis/general/display.py
+++ b/artemis/general/display.py
@@ -257,8 +257,8 @@ def surround_with_header(string, width, char='-'):
     :param char: Character to repeat
     :return: A header, whose length will be
     """
-    left = (width-len(string)-1)/2
-    right = (width-len(string)-2)/2
+    left = (width-len(string)-1)//2
+    right = (width-len(string)-2)//2
     return char*left+' '+string+' '+char*right
 
 

--- a/artemis/general/display.py
+++ b/artemis/general/display.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 from artemis.fileman.local_dir import make_file_dir
 from artemis.general.should_be_builtins import izip_equal
 import numpy as np
+from six.moves import xrange
 
 __author__ = 'peter'
 

--- a/artemis/general/ezprofile.py
+++ b/artemis/general/ezprofile.py
@@ -58,5 +58,5 @@ class EZProfiler(object):
             return '%s: Elapsed time is %.4gs' % (self.profiler_name, self._lap_times['Stop']-self._lap_times['Start'])
         else:
             deltas = OrderedDict((key, self._lap_times[key] - self._lap_times[last_key]) for last_key, key in zip(keys[:-1], keys[1:]))
-            return self.profiler_name + '\n  '.join(['']+['%s: Elapsed time is %.4gs' % (key, val) for key, val in deltas.iteritems()] +
+            return self.profiler_name + '\n  '.join(['']+['%s: Elapsed time is %.4gs' % (key, val) for key, val in deltas.items()] +
                 (['Total: %.4gs' % (self._lap_times.values()[-1] - self._lap_times.values()[0])] if len(deltas)>1 else []))

--- a/artemis/general/functional.py
+++ b/artemis/general/functional.py
@@ -1,9 +1,7 @@
 import inspect
 from collections import OrderedDict
 from functools import partial
-
 import collections
-
 from artemis.general.should_be_builtins import separate_common_items
 
 
@@ -17,10 +15,16 @@ def get_partial_chain(f):
         h = partial(g, a=2)
         assert [f, g, h] == get_partial_chain(h)
 
+    WARNING: Python 3 automatically collapses partials - so in Python 3 this chain will never be longer than 2!
+
     :param f: A function, possibly a partial
     :return: A list of functions, starting with the root
     """
     return get_partial_chain(f.func) + [f] if isinstance(f, partial) else [f]
+
+
+def get_partial_root(f):
+    return get_partial_chain(f)[0]
 
 
 def infer_function_and_derived_arg_values(f):

--- a/artemis/general/functional.py
+++ b/artemis/general/functional.py
@@ -78,7 +78,7 @@ def infer_arg_values(f, *args, **kwargs):
     assert set(all_arg_names).issubset(args_with_values), "Arguments {} require values but are not given any.  ".format(tuple(set(all_arg_names).difference(args_with_values)))
     assert len(args) <= len(all_arg_names), "You provided {} arguments, but the function only takes {}".format(len(args), len(all_arg_names))
     full_args = tuple(
-        zip(all_arg_names, args)  # Handle unnamed args f(1, 2)
+        list(zip(all_arg_names, args))  # Handle unnamed args f(1, 2)
         + [(name, kwargs[name] if name in kwargs else default_args[name]) for name in all_arg_names[len(args):]]  # Handle named keyworkd args f(a=1, b=2)
         + [(name, kwargs[name]) for name in kwargs if name not in all_arg_names[len(args):]]  # Need to handle case if f takes **kwargs
         )

--- a/artemis/general/functional.py
+++ b/artemis/general/functional.py
@@ -37,7 +37,7 @@ def infer_function_and_derived_arg_values(f):
     partial_chain = get_partial_chain(f)
     root, partials = partial_chain[0], partial_chain[1:]
     assert all(len(pf.args)==0 for pf in partials), "We don't handle unnamed arguments for now.  Add this functionality if necessary"
-    overrides = dict((argname, argval) for pf in partials for argname, argval in pf.keywords.iteritems())  # Note that later updates on the same args go into the dict
+    overrides = dict((argname, argval) for pf in partials for argname, argval in pf.keywords.items())  # Note that later updates on the same args go into the dict
     full_arg_list = infer_arg_values(root, **overrides)
     return root, full_arg_list
 
@@ -74,7 +74,7 @@ def infer_arg_values(f, *args, **kwargs):
     all_arg_names, varargs_name, kwargs_name, defaults = inspect.getargspec(f)
     assert varargs_name is None, "This function doesn't work with unnamed args"
     default_args = {k: v for k, v in zip(all_arg_names[len(all_arg_names)-(len(defaults) if defaults is not None else 0):], defaults if defaults is not None else [])}
-    args_with_values = set(all_arg_names[:len(args)]+default_args.keys()+kwargs.keys())
+    args_with_values = set(all_arg_names[:len(args)]+list(default_args.keys())+list(kwargs.keys()))
     assert set(all_arg_names).issubset(args_with_values), "Arguments {} require values but are not given any.  ".format(tuple(set(all_arg_names).difference(args_with_values)))
     assert len(args) <= len(all_arg_names), "You provided {} arguments, but the function only takes {}".format(len(args), len(all_arg_names))
     full_args = tuple(
@@ -82,7 +82,7 @@ def infer_arg_values(f, *args, **kwargs):
         + [(name, kwargs[name] if name in kwargs else default_args[name]) for name in all_arg_names[len(args):]]  # Handle named keyworkd args f(a=1, b=2)
         + [(name, kwargs[name]) for name in kwargs if name not in all_arg_names[len(args):]]  # Need to handle case if f takes **kwargs
         )
-    duplicates = tuple(item for item, count in collections.Counter([a for a, _ in full_args]).iteritems() if count > 1)
+    duplicates = tuple(item for item, count in collections.Counter([a for a, _ in full_args]).items() if count > 1)
     assert len(duplicates)==0, 'Arguments {} have been defined multiple times: {}'.format(duplicates, full_args)
 
     common_args, (different_args, different_given_args) = separate_common_items([tuple(all_arg_names), tuple(n for n, _ in full_args)])

--- a/artemis/general/hashing.py
+++ b/artemis/general/hashing.py
@@ -3,7 +3,7 @@ import pickle
 from collections import OrderedDict
 import itertools
 import numpy as np
-from six import string_types
+from six import string_types, next
 
 _ALREADY_SEEN_CODE = 'dbf056790fabd3c7b79c1ddab7b7ee49'
 _END_CODE = 'e0abd6b36d6e295b6c8859cdffc773df'
@@ -44,7 +44,7 @@ def compute_fixed_hash(obj, try_objects=False, _hasher = None, _memo = None, _co
 
     if _count is None:
         _count = itertools.count()
-    _memo[id(obj)] = _count.next()
+    _memo[id(obj)] =next(_count)
 
     if _hasher is None:
         _hasher = hashlib.md5()

--- a/artemis/general/hashing.py
+++ b/artemis/general/hashing.py
@@ -3,7 +3,6 @@ import pickle
 from collections import OrderedDict
 import itertools
 import numpy as np
-from past.builtins import basestring
 from six import string_types
 
 _ALREADY_SEEN_CODE = 'dbf056790fabd3c7b79c1ddab7b7ee49'

--- a/artemis/general/hashing.py
+++ b/artemis/general/hashing.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 import itertools
 import numpy as np
 from past.builtins import basestring
+from six import string_types
 
 _ALREADY_SEEN_CODE = 'dbf056790fabd3c7b79c1ddab7b7ee49'
 _END_CODE = 'e0abd6b36d6e295b6c8859cdffc773df'
@@ -36,7 +37,7 @@ def compute_fixed_hash(obj, try_objects=False, _hasher = None, _memo = None, _co
     """
     if _memo is None:
         _memo = {}
-    elif not isinstance(obj, (np.ndarray, int, float, string_types, bool)) and id(obj) in _memo:
+    elif not isinstance(obj, (np.ndarray, int, float, bool)+string_types) and id(obj) in _memo:
         _hasher.update(_ALREADY_SEEN_CODE)
         _hasher.update(str(_memo[id(obj)]))
         _hasher.update(_END_CODE)
@@ -56,7 +57,7 @@ def compute_fixed_hash(obj, try_objects=False, _hasher = None, _memo = None, _co
         _hasher.update(pickle.dumps(obj.dtype, protocol=2))
         _hasher.update(pickle.dumps(obj.shape, protocol=2))
         _hasher.update(obj.tostring())
-    elif isinstance(obj, (int, string_types, float, bool)) or (obj is None) or (obj in (int, str, float, bool)):
+    elif isinstance(obj, (int, float, bool)+string_types) or (obj is None) or (obj in (int, str, float, bool)):
         _hasher.update(pickle.dumps(obj, protocol=2))
     elif isinstance(obj, (list, tuple)):
         for el in obj:

--- a/artemis/general/hashing.py
+++ b/artemis/general/hashing.py
@@ -5,8 +5,8 @@ import itertools
 import numpy as np
 from six import string_types, next
 
-_ALREADY_SEEN_CODE = 'dbf056790fabd3c7b79c1ddab7b7ee49'
-_END_CODE = 'e0abd6b36d6e295b6c8859cdffc773df'
+_ALREADY_SEEN_CODE = 'dbf056790fabd3c7b79c1ddab7b7ee49'.encode('utf-8')
+_END_CODE = 'e0abd6b36d6e295b6c8859cdffc773df'.encode('utf-8')
 
 
 def fixed_hash_eq(obj1, obj2):

--- a/artemis/general/hashing.py
+++ b/artemis/general/hashing.py
@@ -3,6 +3,7 @@ import pickle
 from collections import OrderedDict
 import itertools
 import numpy as np
+from past.builtins import basestring
 
 _ALREADY_SEEN_CODE = 'dbf056790fabd3c7b79c1ddab7b7ee49'
 _END_CODE = 'e0abd6b36d6e295b6c8859cdffc773df'
@@ -35,7 +36,7 @@ def compute_fixed_hash(obj, try_objects=False, _hasher = None, _memo = None, _co
     """
     if _memo is None:
         _memo = {}
-    elif not isinstance(obj, (np.ndarray, int, float, basestring, bool)) and id(obj) in _memo:
+    elif not isinstance(obj, (np.ndarray, int, float, string_types, bool)) and id(obj) in _memo:
         _hasher.update(_ALREADY_SEEN_CODE)
         _hasher.update(str(_memo[id(obj)]))
         _hasher.update(_END_CODE)
@@ -55,7 +56,7 @@ def compute_fixed_hash(obj, try_objects=False, _hasher = None, _memo = None, _co
         _hasher.update(pickle.dumps(obj.dtype, protocol=2))
         _hasher.update(pickle.dumps(obj.shape, protocol=2))
         _hasher.update(obj.tostring())
-    elif isinstance(obj, (int, basestring, float, bool)) or (obj is None) or (obj in (int, str, float, bool)):
+    elif isinstance(obj, (int, string_types, float, bool)) or (obj is None) or (obj in (int, str, float, bool)):
         _hasher.update(pickle.dumps(obj, protocol=2))
     elif isinstance(obj, (list, tuple)):
         for el in obj:

--- a/artemis/general/hashing.py
+++ b/artemis/general/hashing.py
@@ -51,7 +51,7 @@ def compute_fixed_hash(obj, try_objects=False, _hasher = None, _memo = None, _co
 
     kwargs = dict(_hasher=_hasher, try_objects=try_objects, _memo=_memo, _count=_count)
 
-    _hasher.update(obj.__class__.__name__)
+    _hasher.update(obj.__class__.__name__.encode('utf-8'))
     if isinstance(obj, np.ndarray):
         _hasher.update(pickle.dumps(obj.dtype, protocol=2))
         _hasher.update(pickle.dumps(obj.shape, protocol=2))

--- a/artemis/general/hashing.py
+++ b/artemis/general/hashing.py
@@ -38,7 +38,7 @@ def compute_fixed_hash(obj, try_objects=False, _hasher = None, _memo = None, _co
         _memo = {}
     elif not isinstance(obj, (np.ndarray, int, float, bool)+string_types) and id(obj) in _memo:
         _hasher.update(_ALREADY_SEEN_CODE)
-        _hasher.update(str(_memo[id(obj)]))
+        _hasher.update(str(_memo[id(obj)]).encode('utf-8'))
         _hasher.update(_END_CODE)
         return _memo[id(obj)]
 

--- a/artemis/general/mymath.py
+++ b/artemis/general/mymath.py
@@ -407,8 +407,8 @@ def conv_fanout(input_len, kernel_len, conv_mode):
     :param conv_mode:
     :return:
     """
-    left_pad = kernel_len / 2 if conv_mode == 'same' else 0 if conv_mode == 'valid' else conv_mode if isinstance(conv_mode, int) else bad_value(conv_mode)
-    right_pad = (kernel_len-1) / 2 if conv_mode == 'same' else 0 if conv_mode == 'valid' else conv_mode if isinstance(conv_mode, int) else bad_value(conv_mode)
+    left_pad = kernel_len // 2 if conv_mode == 'same' else 0 if conv_mode == 'valid' else conv_mode if isinstance(conv_mode, int) else bad_value(conv_mode)
+    right_pad = (kernel_len-1) // 2 if conv_mode == 'same' else 0 if conv_mode == 'valid' else conv_mode if isinstance(conv_mode, int) else bad_value(conv_mode)
     full_range = np.arange(left_pad + input_len + right_pad)
     max_fanout = np.minimum(kernel_len, np.maximum(input_len-kernel_len+1+2*left_pad, 1))
     fanout_over_full_range = np.minimum(max_fanout, np.minimum(full_range+1, full_range[::-1]+1))

--- a/artemis/general/mymath.py
+++ b/artemis/general/mymath.py
@@ -6,6 +6,8 @@ try:
     from scipy import weave
 except ImportError:
     logging.warn("Could not import scipy.weave.  That's ok, ignore this unless you need it.")
+from six.moves import xrange
+
 __author__ = 'peter'
 
 # Note - this module used to be called math, but it somehow results in a numpy import error

--- a/artemis/general/nested_structures.py
+++ b/artemis/general/nested_structures.py
@@ -1,13 +1,13 @@
 from collections import OrderedDict
-
 import itertools
 import numpy as np
 from six.moves import xrange
+from six import string_types
 
 __author__ = 'peter'
 
 
-def flatten_struct(struct, primatives = (int, float, np.ndarray, basestring, bool), custom_handlers = {},
+def flatten_struct(struct, primatives = (int, float, np.ndarray, bool)+string_types, custom_handlers = {},
         break_into_objects = True, detect_duplicates = True, first_dict_is_namespace=False, memo = None):
     """
     Given some nested struct, return a list<*(str, primative)>, where primative
@@ -37,7 +37,7 @@ def flatten_struct(struct, primatives = (int, float, np.ndarray, basestring, boo
         return [(None, handler(struct))]
     elif isinstance(struct, dict):
         return [
-            (("[{}]{}").format(("'{}'".format(key) if isinstance(key, basestring) else key), subkey if subkey is not None else ''), v) if not first_dict_is_namespace else
+            (("[{}]{}").format(("'{}'".format(key) if isinstance(key, string_types) else key), subkey if subkey is not None else ''), v) if not first_dict_is_namespace else
             (("{}{}").format(key, subkey if subkey is not None else ''), v)
             for key in (struct.keys() if isinstance(struct, OrderedDict) else sorted(struct.keys()))
             for subkey, v in flatten_struct(struct[key], custom_handlers=custom_handlers, primatives=primatives, break_into_objects=break_into_objects, memo=memo, detect_duplicates=detect_duplicates)

--- a/artemis/general/nested_structures.py
+++ b/artemis/general/nested_structures.py
@@ -2,6 +2,7 @@ from collections import OrderedDict
 
 import itertools
 import numpy as np
+from six.moves import xrange
 
 __author__ = 'peter'
 

--- a/artemis/general/nested_structures.py
+++ b/artemis/general/nested_structures.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 import itertools
 import numpy as np
 from six.moves import xrange
-from six import string_types
+from six import string_types, next
 
 __author__ = 'peter'
 
@@ -78,7 +78,7 @@ def get_meta_object(data_object, containers = _primitive_containers):
         if isinstance(data_object, (list, tuple, set)):
             return type(data_object)(get_meta_object(x) for x in data_object)
         elif isinstance(data_object, dict):
-            return type(data_object)((k, get_meta_object(v)) for k, v in data_object.iteritems())
+            return type(data_object)((k, get_meta_object(v)) for k, v in data_object.items())
     else:
         return type(data_object)
 
@@ -160,7 +160,7 @@ def get_leaf_values(data_object, containers = _primitive_containers):
         if isinstance(data_object, (list, tuple)):
             leaf_values += [val for x in data_object for val in get_leaf_values(x)]
         elif isinstance(data_object, OrderedDict):
-            leaf_values += [val for k, x in data_object.iteritems() for val in get_leaf_values(x)]
+            leaf_values += [val for k, x in data_object.items() for val in get_leaf_values(x)]
         elif isinstance(data_object, dict):
             leaf_values += [val for k in sorted(data_object.keys()) for val in get_leaf_values(data_object[k])]
         else:
@@ -184,13 +184,13 @@ def _fill_meta_object(meta_object, data_iteratable, assert_fully_used = True, ch
             if isinstance(meta_object, (list, tuple, set)):
                 filled_object = type(meta_object)(_fill_meta_object(x, data_iteratable, assert_fully_used=False, check_types=check_types) for x in meta_object)
             elif isinstance(meta_object, OrderedDict):
-                filled_object = type(meta_object)((k, _fill_meta_object(val, data_iteratable, assert_fully_used=False, check_types=check_types)) for k, val in meta_object.iteritems())
+                filled_object = type(meta_object)((k, _fill_meta_object(val, data_iteratable, assert_fully_used=False, check_types=check_types)) for k, val in meta_object.items())
             elif isinstance(meta_object, dict):
                 filled_object = type(meta_object)((k, _fill_meta_object(meta_object[k], data_iteratable, assert_fully_used=False, check_types=check_types)) for k in sorted(meta_object.keys()))
             else:
                 raise Exception('Cannot handle container type: "{}"'.format(type(meta_object)))
         else:
-            next_data = data_iteratable.next()
+            next_data = next(data_iteratable)
             if check_types and meta_object is not type(next_data):
                 raise TypeError('The type of the data object: {} did not match type from the meta object: {}'.format(type(next_data), meta_object))
             filled_object = next_data
@@ -199,7 +199,7 @@ def _fill_meta_object(meta_object, data_iteratable, assert_fully_used = True, ch
 
     if assert_fully_used:
         try:
-            data_iteratable.next()
+            next(data_iteratable)
             raise TypeError('It appears that the data object you were using to fill your meta object had more data than could fit.')
         except StopIteration:
             pass

--- a/artemis/general/nested_structures.py
+++ b/artemis/general/nested_structures.py
@@ -19,7 +19,7 @@ def flatten_struct(struct, primatives = (int, float, np.ndarray, bool)+string_ty
     :param custum_handlers: A dict<type:func> where func has the form data = func(obj).  These
         will be called if the type of the struct is in the dict of custom handlers.
     :param break_into_objects: True if you want to break into objects to see what's inside.
-    :return: list<*(str, primative)>
+    :return: list<*(str , primative)>
     """
     if memo is None:
         memo = {}
@@ -39,7 +39,7 @@ def flatten_struct(struct, primatives = (int, float, np.ndarray, bool)+string_ty
         return [
             (("[{}]{}").format(("'{}'".format(key) if isinstance(key, string_types) else key), subkey if subkey is not None else ''), v) if not first_dict_is_namespace else
             (("{}{}").format(key, subkey if subkey is not None else ''), v)
-            for key in (struct.keys() if isinstance(struct, OrderedDict) else sorted(struct.keys()))
+            for key in (struct.keys() if isinstance(struct, OrderedDict) else sorted(struct.keys(), key = str))
             for subkey, v in flatten_struct(struct[key], custom_handlers=custom_handlers, primatives=primatives, break_into_objects=break_into_objects, memo=memo, detect_duplicates=detect_duplicates)
             ]
     elif isinstance(struct, (list, tuple)):
@@ -52,7 +52,7 @@ def flatten_struct(struct, primatives = (int, float, np.ndarray, bool)+string_ty
         return []
     elif break_into_objects:  # It's some kind of object, lets break it down.
         return [(".%s%s" % (key, subkey if subkey is not None else ''), v)
-            for key in sorted(struct.__dict__.keys())
+            for key in sorted(struct.__dict__.keys(), key = str)
             for subkey, v in flatten_struct(struct.__dict__[key], custom_handlers=custom_handlers, primatives=primatives, break_into_objects=break_into_objects, memo=memo, detect_duplicates=detect_duplicates)
             ]
     else:
@@ -162,7 +162,7 @@ def get_leaf_values(data_object, containers = _primitive_containers):
         elif isinstance(data_object, OrderedDict):
             leaf_values += [val for k, x in data_object.items() for val in get_leaf_values(x)]
         elif isinstance(data_object, dict):
-            leaf_values += [val for k in sorted(data_object.keys()) for val in get_leaf_values(data_object[k])]
+            leaf_values += [val for k in sorted(data_object.keys(), key = str) for val in get_leaf_values(data_object[k])]
         else:
             raise Exception('Have no way to consistently extract leaf values from a {}'.format(data_object))
         return leaf_values
@@ -186,7 +186,7 @@ def _fill_meta_object(meta_object, data_iteratable, assert_fully_used = True, ch
             elif isinstance(meta_object, OrderedDict):
                 filled_object = type(meta_object)((k, _fill_meta_object(val, data_iteratable, assert_fully_used=False, check_types=check_types)) for k, val in meta_object.items())
             elif isinstance(meta_object, dict):
-                filled_object = type(meta_object)((k, _fill_meta_object(meta_object[k], data_iteratable, assert_fully_used=False, check_types=check_types)) for k in sorted(meta_object.keys()))
+                filled_object = type(meta_object)((k, _fill_meta_object(meta_object[k], data_iteratable, assert_fully_used=False, check_types=check_types)) for k in sorted(meta_object.keys(), key=str))
             else:
                 raise Exception('Cannot handle container type: "{}"'.format(type(meta_object)))
         else:

--- a/artemis/general/redict.py
+++ b/artemis/general/redict.py
@@ -26,7 +26,7 @@ class ReDict(dict):
         match_found = False
         if index is None:
             return dict.__getitem__(self, None)
-        for k, v in self.iteritems():
+        for k, v in self.items():
             if k is not None and re.match(k, index) is not None:
                 if match_found:
                     raise MultipleMatchesError('Multiple Matches to expression %s: %s.  If this is what you want use get_matches'
@@ -48,7 +48,7 @@ class ReDict(dict):
         """
         Get matching keys, NOT including the default None key.
         """
-        matching_dict = {k: v for k, v in self.iteritems() if k is not None and re.match(k, index) is not None}
+        matching_dict = {k: v for k, v in self.items() if k is not None and re.match(k, index) is not None}
         return ReDict(matching_dict) if as_redict else matching_dict
 
     def get(self, item, default):
@@ -73,7 +73,7 @@ class ReCurseDict(ReDict):
         :param dict_initialzer: Don't try to be funny here an give dicts containing themselves.
         """
         ReDict.__init__(self, dict_initialzer)
-        for k, v in self.iteritems():
+        for k, v in self.items():
             if isinstance(v, dict):
                 self[k] = ReCurseDict(v)
 

--- a/artemis/general/redict.py
+++ b/artemis/general/redict.py
@@ -42,7 +42,7 @@ class ReDict(dict):
 
     def __contains__(self, index):
 
-        return (None in self.viewkeys()) if index is None else any(re.match(k, index) for k in self if k is not None)
+        return (None in self.keys()) if index is None else any(re.match(k, index) for k in self if k is not None)
 
     def get_matches(self, index, as_redict = True):
         """

--- a/artemis/general/redict.py
+++ b/artemis/general/redict.py
@@ -1,4 +1,7 @@
 import re
+
+from six import string_types
+
 __author__ = 'peter'
 
 
@@ -17,7 +20,7 @@ class ReDict(dict):
             or None.  None in this case means default - in case nothing else matches.
         """
         dict.__init__(self, dict_initializer)
-        assert all(isinstance(k, basestring) or k is None for k in self), 'All keys to a Redict must be strings or None'
+        assert all(isinstance(k, string_types) or k is None for k in self), 'All keys to a Redict must be strings or None'
 
     def __getitem__(self, index):
         match_found = False

--- a/artemis/general/should_be_builtins.py
+++ b/artemis/general/should_be_builtins.py
@@ -1,8 +1,9 @@
 import inspect
 from collections import OrderedDict
 import itertools
-
 import os
+
+from six.moves import xrange
 
 __author__ = 'peter'
 

--- a/artemis/general/should_be_builtins.py
+++ b/artemis/general/should_be_builtins.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 import itertools
 import os
 
-from six.moves import xrange
+from six.moves import xrange, zip_longest
 
 __author__ = 'peter'
 
@@ -17,7 +17,7 @@ def all_equal(elements):
     """
     element_iterator = iter(elements)
     try:
-        first = element_iterator.next() # Will throw exception
+        first = next(element_iterator) # Will throw exception
     except StopIteration:
         return True
     return all(a == first for a in element_iterator)
@@ -143,7 +143,7 @@ def izip_equal(*iterables):
     :return:
     """
     sentinel = object()
-    for combo in itertools.izip_longest(*iterables, fillvalue=sentinel):
+    for combo in itertools.zip_longest(*iterables, fillvalue=sentinel):
         if any(sentinel is c for c in combo):
             raise ValueError('Iterables have different lengths')
         yield combo

--- a/artemis/general/should_be_builtins.py
+++ b/artemis/general/should_be_builtins.py
@@ -334,3 +334,18 @@ def file_path_to_absolute_module(file_path):
 
 def assert_option(choice, possiblilties):
     assert choice in possiblilties, '"{}" was not in the list of possible choices: {}'.format(choice, possiblilties)
+
+try:
+    from contextlib import nested  # Python 2
+except ImportError:
+    from contextlib import ExitStack, contextmanager
+
+    @contextmanager
+    def nested(*contexts):
+        """
+        Reimplementation of nested in python 3.
+        """
+        with ExitStack() as stack:
+            for ctx in contexts:
+                stack.enter_context(ctx)
+            yield contexts

--- a/artemis/general/should_be_builtins.py
+++ b/artemis/general/should_be_builtins.py
@@ -143,7 +143,7 @@ def izip_equal(*iterables):
     :return:
     """
     sentinel = object()
-    for combo in itertools.zip_longest(*iterables, fillvalue=sentinel):
+    for combo in zip_longest(*iterables, fillvalue=sentinel):
         if any(sentinel is c for c in combo):
             raise ValueError('Iterables have different lengths')
         yield combo

--- a/artemis/general/tables.py
+++ b/artemis/general/tables.py
@@ -1,6 +1,7 @@
 import itertools
 
 from artemis.general.should_be_builtins import all_equal_deprecated, all_equal
+from six.moves import xrange
 
 
 def build_table(lookup_fcn, row_categories, column_categories, clear_repeated_headers = True, prettify_labels = True,

--- a/artemis/general/tables.py
+++ b/artemis/general/tables.py
@@ -1,5 +1,7 @@
 import itertools
 
+from six import string_types
+
 from artemis.general.should_be_builtins import all_equal_deprecated, all_equal
 from six.moves import xrange
 
@@ -44,8 +46,8 @@ def build_table(lookup_fcn, row_categories, column_categories, clear_repeated_he
     :return: A list of rows.
     """
     # Now, build that table!
-    single_row_category = all(isinstance(c, basestring) for c in row_categories)
-    single_column_category = all(isinstance(c, basestring) for c in column_categories)
+    single_row_category = all(isinstance(c, string_types) for c in row_categories)
+    single_column_category = all(isinstance(c, string_types) for c in column_categories)
 
     if single_row_category:
         row_categories = [row_categories]

--- a/artemis/general/tables.py
+++ b/artemis/general/tables.py
@@ -56,7 +56,7 @@ def build_table(lookup_fcn, row_categories, column_categories, clear_repeated_he
     if row_header_labels is not None:
         assert len(row_header_labels) == len(row_categories)
     rows = []
-    column_headers = zip(*itertools.product(*column_categories))
+    column_headers = list(zip(*itertools.product(*column_categories)))
     for i, c in enumerate(column_headers):
         row_header = row_header_labels if row_header_labels is not None and i==len(column_headers)-1 else [' ']*len(row_categories)
         row = row_header+(blank_out_repeats(c) if clear_repeated_headers else list(c))

--- a/artemis/general/test_functional.py
+++ b/artemis/general/test_functional.py
@@ -75,8 +75,8 @@ def test_get_derived_function_args():
 
     with raises(AssertionError):  # AssertionError: Arguments ('a',) require values but are not given any.
         infer_derived_arg_values(f)
-    assert infer_derived_arg_values(g).items() == [('a', 2), ('b', 1)]
-    assert infer_derived_arg_values(h).items() == [('a', 2), ('b', 3)]
+    assert list(infer_derived_arg_values(g).items()) == [('a', 2), ('b', 1)]
+    assert list(infer_derived_arg_values(h).items()) == [('a', 2), ('b', 3)]
     with raises(AssertionError):
         infer_derived_arg_values(j)
 

--- a/artemis/general/test_functional.py
+++ b/artemis/general/test_functional.py
@@ -1,4 +1,6 @@
 from functools import partial
+
+import sys
 from pytest import raises
 from artemis.general.functional import infer_arg_values, get_partial_chain, infer_derived_arg_values
 
@@ -63,7 +65,13 @@ def test_get_partial_chain():
         return a+b
     g = partial(f, b=3)
     h = partial(g, a=2)
-    assert [f, g, h] == get_partial_chain(h)
+
+    if sys.version_info < (3, 0):  # Python 2.X
+        assert [f, g, h] == get_partial_chain(h)
+    else: # Python 3.X
+        base, part = get_partial_chain(h)
+        assert base is f
+        assert part.keywords == {'a': 2, 'b': 3}
 
 
 def test_get_derived_function_args():

--- a/artemis/general/test_functional.py
+++ b/artemis/general/test_functional.py
@@ -8,9 +8,9 @@ def test_get_full_args():
     def func(a, b):
         return a+b
 
-    assert infer_arg_values(func, a=1, b=3).items() == [('a', 1), ('b', 3)]
-    assert infer_arg_values(func, 1, b=3).items() == [('a', 1), ('b', 3)]
-    assert infer_arg_values(func, 1, 3).items() == [('a', 1), ('b', 3)]
+    assert list(infer_arg_values(func, a=1, b=3).items()) == [('a', 1), ('b', 3)]
+    assert list(infer_arg_values(func, 1, b=3).items()) == [('a', 1), ('b', 3)]
+    assert list(infer_arg_values(func, 1, 3).items()) == [('a', 1), ('b', 3)]
     with raises(AssertionError):  # AssertionError: Arguments ('a', 'b') require values but are not given any.
         infer_arg_values(func, )
     with raises(AssertionError):  # AssertionError: Arguments ('a',) require values but are not given any.
@@ -26,9 +26,9 @@ def test_get_full_args():
 
     def func_with_defaults(a, b=4):
         return a+b
-    assert infer_arg_values(func_with_defaults, a=1).items() == [('a', 1), ('b', 4)]
-    assert infer_arg_values(func_with_defaults, a=1, b=3).items() == [('a', 1), ('b', 3)]
-    assert infer_arg_values(func_with_defaults, 1).items() == [('a', 1), ('b', 4)]
+    assert list(infer_arg_values(func_with_defaults, a=1).items()) == [('a', 1), ('b', 4)]
+    assert list(infer_arg_values(func_with_defaults, a=1, b=3).items()) == [('a', 1), ('b', 3)]
+    assert list(infer_arg_values(func_with_defaults, 1).items()) == [('a', 1), ('b', 4)]
     with raises(AssertionError):  # AssertionError: Arguments ('a',) require values but are not given any.
         infer_arg_values(func_with_defaults, )
     with raises(AssertionError):  # AssertionError: Arguments ('a',) require values but are not given any.
@@ -44,16 +44,16 @@ def test_get_full_args():
 
     def func_with_kwargs(a, b=4, **kwargs):
         return a+b
-    assert infer_arg_values(func_with_kwargs, a=1).items() == [('a', 1), ('b', 4)]
-    assert infer_arg_values(func_with_kwargs, a=1, b=3).items() == [('a', 1), ('b', 3)]
-    assert infer_arg_values(func_with_kwargs, 1).items() == [('a', 1), ('b', 4)]
-    infer_arg_values(func_with_kwargs, a=1, b=3, c=5) == [('a', 1), ('b', 3), ('c', 5)]
+    assert list(infer_arg_values(func_with_kwargs, a=1).items()) == [('a', 1), ('b', 4)]
+    assert list(infer_arg_values(func_with_kwargs, a=1, b=3).items()) == [('a', 1), ('b', 3)]
+    assert list(infer_arg_values(func_with_kwargs, 1).items()) == [('a', 1), ('b', 4)]
+    list(infer_arg_values(func_with_kwargs, a=1, b=3, c=5)) == [('a', 1), ('b', 3), ('c', 5)]
     with raises(AssertionError):  # AssertionError: Arguments ('a',) require values but are not given any.
         infer_arg_values(func_with_kwargs, )
     with raises(AssertionError):  # AssertionError: Arguments ('a',) require values but are not given any.
         infer_arg_values(func_with_kwargs, b=3)
     with raises(AssertionError):  # AssertionError: You provided 3 arguments, but the function only takes 2
-        print(infer_arg_values(func_with_kwargs, 1, 2, 5))
+        print(list(infer_arg_values(func_with_kwargs, 1, 2, 5)))
     with raises(AssertionError):  # AssertionError: Arguments ('b',) have been defined multiple times: (('a', 1), ('b', 2), ('b', 5))
         infer_arg_values(func_with_kwargs, 1, 2, b=5)
 

--- a/artemis/general/test_hashing.py
+++ b/artemis/general/test_hashing.py
@@ -3,7 +3,7 @@ import numpy as np
 
 
 def test_compute_fixed_hash():
-    complex_obj = [1, 'd', {'a': 4, 'b': np.arange(10)}, (7, range(10))]
+    complex_obj = [1, 'd', {'a': 4, 'b': np.arange(10)}, (7, list(range(10)))]
     original_code = compute_fixed_hash(complex_obj)
     assert compute_fixed_hash(complex_obj) == original_code == '6c98fabc301361863f321f6149a8a12a'
     complex_obj[2]['b'][6]=0

--- a/artemis/general/test_hashing.py
+++ b/artemis/general/test_hashing.py
@@ -1,13 +1,23 @@
 from artemis.general.hashing import compute_fixed_hash
 import numpy as np
+import sys
+
+_IS_PYTHON_3 = sys.version_info > (3, 0)
 
 
 def test_compute_fixed_hash():
+    # Not really sure why the fixed hash differes between python 2 and 4 here (maybe something do do with changes to strings)
+
     complex_obj = [1, 'd', {'a': 4, 'b': np.arange(10)}, (7, list(range(10)))]
     original_code = compute_fixed_hash(complex_obj)
-    assert compute_fixed_hash(complex_obj) == original_code == '6c98fabc301361863f321f6149a8a12a'
+
+    expected_code = 'c9b83dd2e1099c3bcbb05e3c69327c72' if _IS_PYTHON_3 else '8aee1f739fc9a612ed72e14682026627'
+
+    assert compute_fixed_hash(complex_obj) == original_code == expected_code
     complex_obj[2]['b'][6]=0
-    assert compute_fixed_hash(complex_obj) == '8aee1f739fc9a612ed72e14682026627' != original_code
+
+    expected_code = 'a783b1f098fca8ccaf977a3123be5ac4' if _IS_PYTHON_3 else '8aee1f739fc9a612ed72e14682026627'
+    assert compute_fixed_hash(complex_obj) == expected_code != original_code
     complex_obj[2]['b'][6]=6  # Revert to old value
     assert compute_fixed_hash(complex_obj) == original_code
 

--- a/artemis/general/test_hashing.py
+++ b/artemis/general/test_hashing.py
@@ -11,12 +11,12 @@ def test_compute_fixed_hash():
     complex_obj = [1, 'd', {'a': 4, 'b': np.arange(10)}, (7, list(range(10)))]
     original_code = compute_fixed_hash(complex_obj)
 
-    expected_code = 'c9b83dd2e1099c3bcbb05e3c69327c72' if _IS_PYTHON_3 else '285f0ff77c0cb6a5fc529ae55775f9dd'
+    expected_code = 'c9b83dd2e1099c3bcbb05e3c69327c72' if _IS_PYTHON_3 else '6c98fabc301361863f321f6149a8a12a'
 
     assert compute_fixed_hash(complex_obj) == original_code == expected_code
     complex_obj[2]['b'][6]=0
 
-    expected_code = 'a783b1f098fca8ccaf977a3123be5ac4' if _IS_PYTHON_3 else '3124854bda236cd50f0cc04bd6f84935'
+    expected_code = 'a783b1f098fca8ccaf977a3123be5ac4' if _IS_PYTHON_3 else '8aee1f739fc9a612ed72e14682026627'
     assert compute_fixed_hash(complex_obj) == expected_code != original_code
     complex_obj[2]['b'][6]=6  # Revert to old value
     assert compute_fixed_hash(complex_obj) == original_code

--- a/artemis/general/test_hashing.py
+++ b/artemis/general/test_hashing.py
@@ -11,12 +11,12 @@ def test_compute_fixed_hash():
     complex_obj = [1, 'd', {'a': 4, 'b': np.arange(10)}, (7, list(range(10)))]
     original_code = compute_fixed_hash(complex_obj)
 
-    expected_code = 'c9b83dd2e1099c3bcbb05e3c69327c72' if _IS_PYTHON_3 else '8aee1f739fc9a612ed72e14682026627'
+    expected_code = 'c9b83dd2e1099c3bcbb05e3c69327c72' if _IS_PYTHON_3 else '285f0ff77c0cb6a5fc529ae55775f9dd'
 
     assert compute_fixed_hash(complex_obj) == original_code == expected_code
     complex_obj[2]['b'][6]=0
 
-    expected_code = 'a783b1f098fca8ccaf977a3123be5ac4' if _IS_PYTHON_3 else '8aee1f739fc9a612ed72e14682026627'
+    expected_code = 'a783b1f098fca8ccaf977a3123be5ac4' if _IS_PYTHON_3 else '3124854bda236cd50f0cc04bd6f84935'
     assert compute_fixed_hash(complex_obj) == expected_code != original_code
     complex_obj[2]['b'][6]=6  # Revert to old value
     assert compute_fixed_hash(complex_obj) == original_code

--- a/artemis/general/test_mymath.py
+++ b/artemis/general/test_mymath.py
@@ -1,8 +1,10 @@
 import pytest
 
-from artemis.general.mymath import softmax, cummean, cumvar, sigm, expected_sigm_of_norm, mode, cummode, normalize, is_parallel, \
-    align_curves, angle_between, fixed_diff, decaying_cumsum, geosum, selective_sum, conv_fanout, conv2_fanout_map
+from artemis.general.mymath import (softmax, cummean, cumvar, sigm, expected_sigm_of_norm, mode, cummode, normalize, is_parallel,
+    align_curves, angle_between, fixed_diff, decaying_cumsum, geosum, selective_sum, conv_fanout, conv2_fanout_map)
 import numpy as np
+from six.moves import xrange
+
 __author__ = 'peter'
 
 

--- a/artemis/general/test_nested_structures.py
+++ b/artemis/general/test_nested_structures.py
@@ -1,5 +1,4 @@
 from six import string_types
-
 from artemis.general.nested_structures import (flatten_struct, get_meta_object, NestedType,
     seqstruct_to_structseq, structseq_to_seqstruct, nested_map, get_leaf_values)
 import numpy as np

--- a/artemis/general/test_nested_structures.py
+++ b/artemis/general/test_nested_structures.py
@@ -1,3 +1,5 @@
+from six import string_types
+
 from artemis.general.nested_structures import (flatten_struct, get_meta_object, NestedType,
     seqstruct_to_structseq, structseq_to_seqstruct, nested_map, get_leaf_values)
 import numpy as np
@@ -86,7 +88,7 @@ def test_seqstruct_to_structseq_and_inverse():
 
 
 def test_nested_map():
-    func = lambda x: x*2 if isinstance(x, (int, float)) else x+'  Not!' if isinstance(x, basestring) else x
+    func = lambda x: x*2 if isinstance(x, (int, float)) else x+'  Not!' if isinstance(x, string_types) else x
     assert nested_map(func, 2)==4
     assert nested_map(func, 'God is dead.')=='God is dead.  Not!'
     assert nested_map(func, (1, 2, 3)) == (2, 4, 6)

--- a/artemis/general/test_nested_structures.py
+++ b/artemis/general/test_nested_structures.py
@@ -1,7 +1,8 @@
-from artemis.general.nested_structures import flatten_struct, get_meta_object, NestedType, \
-    seqstruct_to_structseq, structseq_to_seqstruct, nested_map, get_leaf_values
+from artemis.general.nested_structures import (flatten_struct, get_meta_object, NestedType,
+    seqstruct_to_structseq, structseq_to_seqstruct, nested_map, get_leaf_values)
 import numpy as np
 from pytest import raises
+from six.moves import xrange
 
 
 def test_flatten_struct():

--- a/artemis/ml/datasets/cifar.py
+++ b/artemis/ml/datasets/cifar.py
@@ -2,6 +2,7 @@ import pickle
 import os
 
 import numpy as np
+from six.moves import xrange
 
 from artemis.ml.datasets.datasets import DataSet, DataCollection
 from artemis.fileman.file_getter import get_file, get_archive

--- a/artemis/ml/datasets/imagenet.py
+++ b/artemis/ml/datasets/imagenet.py
@@ -4,6 +4,8 @@ from artemis.fileman.file_getter import get_file, unzip_gz
 from artemis.fileman.smart_io import smart_load
 import numpy as np
 import os
+from six.moves import xrange
+
 __author__ = 'peter'
 
 

--- a/artemis/ml/predictors/learning_curve_plots.py
+++ b/artemis/ml/predictors/learning_curve_plots.py
@@ -35,7 +35,7 @@ def plot_learning_curves(learning_curves, xscale = 'sqrt', yscale = 'linear', ha
 
     legend = []
 
-    for (record_name, record), colour in zip(learning_curves.iteritems(), cycle(colours)):
+    for (record_name, record), colour in zip(learning_curves.items(), cycle(colours)):
         times, scores = record.get_results()
         if np.array_equal(times.values()[0], [None]):  # Offline result... make a horizontal line
             assert all(len(s)==1 for s in scores.values())

--- a/artemis/ml/predictors/predictor_comparison.py
+++ b/artemis/ml/predictors/predictor_comparison.py
@@ -294,7 +294,7 @@ class LearningCurveData(object):
         if which_test_set is None:
             assert len(results)==1, 'You failed to specify which test set to use, which would be fine if there was only ' \
                 "one, but there's more than one.  There's %s" % (results.keys(), )
-            return results.values()[0]
+            return next(v for v in results.values())
         else:
             assert which_test_set in results, 'You asked for results for the test set %s, but we only have test sets %s' \
                 % (which_test_set, results.keys())

--- a/artemis/ml/predictors/predictor_comparison.py
+++ b/artemis/ml/predictors/predictor_comparison.py
@@ -66,7 +66,7 @@ def compare_predictors(dataset, online_predictors={}, offline_predictors={}, min
     records = OrderedDict()
 
     # Run the offline predictors
-    for predictor_name, (predictor_type, predictor) in type_constructor_dict.iteritems():
+    for predictor_name, (predictor_type, predictor) in type_constructor_dict.items():
         print('%s\nRunning predictor %s\n%s' % ('='*20, predictor_name, '-'*20))
         records[predictor_name] = \
             assess_offline_predictor(
@@ -141,7 +141,7 @@ def assess_offline_predictor(predictor, dataset, evaluation_function, test_on = 
     record = LearningCurveData()
     predictor.fit(dataset.training_set.input, dataset.training_set.target)
     testing_sets = dataset_to_testing_sets(dataset, test_on)
-    scores = [(k, evaluation_function(process_in_batches(predictor.predict, x, test_batch_size), y)) for k, (x, y) in testing_sets.iteritems()]
+    scores = [(k, evaluation_function(process_in_batches(predictor.predict, x, test_batch_size), y)) for k, (x, y) in testing_sets.items()]
     record.add(None, scores)
     if report_test_scores:
         print('Scores: %s' % (scores, ))
@@ -187,7 +187,7 @@ def assess_online_predictor(predictor, dataset, evaluation_function, test_epochs
         evaluation_function = get_evaluation_function(evaluation_function)
 
     def do_test(current_epoch):
-        scores = [(k, evaluation_function(process_in_batches(prediction_functions[k], x, test_batch_size), y)) for k, (x, y) in testing_sets.iteritems()]
+        scores = [(k, evaluation_function(process_in_batches(prediction_functions[k], x, test_batch_size), y)) for k, (x, y) in testing_sets.items()]
         if report_test_scores:
             print('Scores at Epoch %s: %s, after %.2fs' % (current_epoch, ', '.join('%s: %.3f' % (set_name, score) for set_name, score in scores), time.time()-start_time))
         record.add(current_epoch, scores)
@@ -281,7 +281,7 @@ class LearningCurveData(object):
             scores is a (length_N, n_scores) array indicating the each score at each time
                 OR a (length_N, n_scores, n_reps) array where n_reps indexes each repetition or the same experiment
         """
-        return {k: np.array(t) for k, t in self._times.iteritems()}, OrderedDict((k, np.array(v)) for k, v in self._scores.iteritems())
+        return {k: np.array(t) for k, t in self._times.items()}, OrderedDict((k, np.array(v)) for k, v in self._scores.items())
 
     def get_scores(self, which_test_set = None):
         """

--- a/artemis/ml/predictors/train_and_test.py
+++ b/artemis/ml/predictors/train_and_test.py
@@ -182,8 +182,11 @@ class ModelTestScore(object):
     def values(self):
         return self.scores.values()
 
+    def items(self):
+        return self.scores.items()
+
     def iteritems(self):
-        return self.scores.iteritems()
+        return self.scores.items()
 
     def get_score(self, subset=None, prediction_function=None, cost_name=None):
         if subset is None:
@@ -439,7 +442,7 @@ def plot_info_score_pairs_collection(info_score_pair_sequences, prediction_funct
         info_score_pair_sequences = OrderedDict((ix, ispc) for ix, ispc in enumerate(info_score_pair_sequences))
 
     colours = [p['color'] for p in plt.rcParams['axes.prop_cycle']]
-    for (name, ispc), colour in zip(info_score_pair_sequences.iteritems(), colours):
+    for (name, ispc), colour in zip(info_score_pair_sequences.items(), colours):
         plot_info_score_pairs(ispc, prediction_function = prediction_function, score_measure=score_measure, show=False, name=name)
     if show:
         plt.show()
@@ -654,7 +657,7 @@ class ParameterSchedule(object):
 
     def get_new_value(self, epoch):
         if isinstance(self.schedule, dict):
-            new_value = self.schedule[(e for e in self._reverse_sorted_schedule_checkpoints if e <= epoch).next()]
+            new_value = self.schedule[next(e for e in self._reverse_sorted_schedule_checkpoints if e <= epoch)]
         else:
             new_value = self.schedule(epoch)
         if self.last_value != new_value and self.print_variable_name is not None:

--- a/artemis/ml/predictors/train_and_test.py
+++ b/artemis/ml/predictors/train_and_test.py
@@ -2,6 +2,8 @@
 from collections import OrderedDict
 
 import numpy as np
+from six import string_types
+
 from artemis.general.mymath import softmax, cosine_distance
 from artemis.general.should_be_builtins import remove_duplicates
 from artemis.general.tables import build_table
@@ -482,12 +484,12 @@ def assess_prediction_functions(test_pairs, functions, costs, print_results=Fals
         assert all(callable(f) for name, f in functions)
     if callable(costs):
         costs = [(costs.__name__, costs)]
-    elif isinstance(costs, basestring):
+    elif isinstance(costs, string_types):
         costs = [(costs, get_evaluation_function(costs))]
     elif isinstance(costs, dict):
         costs = costs.items()
     else:
-        costs = [(cost, get_evaluation_function(cost)) if isinstance(cost, basestring) else (cost.__name__, cost) if callable(cost) else cost for cost in costs]
+        costs = [(cost, get_evaluation_function(cost)) if isinstance(cost, string_types) else (cost.__name__, cost) if callable(cost) else cost for cost in costs]
     assert all(callable(cost) for name, cost in costs)
 
     results = ModelTestScore()

--- a/artemis/ml/predictors/train_and_test.py
+++ b/artemis/ml/predictors/train_and_test.py
@@ -233,7 +233,8 @@ class ModelTestScore(object):
     def get_table(self):
         # test_pair_names, function_names, cost_names = [remove_duplicates(k) for k in zip(*self.scores.keys())]
 
-        def lookup( (test_pair_name_, function_name_), cost_name_):
+        def lookup( test_pair_name_and_function_name_, cost_name_):
+            test_pair_name_, function_name_ = test_pair_name_and_function_name_
             return self[test_pair_name_, function_name_, cost_name_]
 
         rows = build_table(
@@ -517,7 +518,7 @@ def print_score_results(score, info=None):
         print('Epoch {} (after {:.3g}s)'.format(info.epoch, info.time))
     test_pair_names, function_names, cost_names = [remove_duplicates(k) for k in zip(*score.keys())]
     rows = build_table(
-        lookup_fcn=lambda (test_pair_name_, function_name_), cost_name_: score[test_pair_name_, function_name_, cost_name_],
+        lookup_fcn=lambda test_pair_name_and_function_name_, cost_name_: score[test_pair_name_and_function_name_[0], test_pair_name_and_function_name_[1], cost_name_],
         row_categories = [[test_pair_name for test_pair_name in test_pair_names], [function_name for function_name in function_names]],
         column_categories = [cost_name for cost_name in cost_names],
         row_header_labels=['Subset', 'Function'],

--- a/artemis/ml/tools/data_splitting.py
+++ b/artemis/ml/tools/data_splitting.py
@@ -1,6 +1,7 @@
-__author__ = 'peter'
 import numpy as np
+from six.moves import xrange
 
+__author__ = 'peter'
 
 def split_data_by_label(data, labels, frac_training = 0.5):
     """

--- a/artemis/ml/tools/iteration.py
+++ b/artemis/ml/tools/iteration.py
@@ -5,7 +5,7 @@ from six import string_types
 
 from artemis.general.should_be_builtins import bad_value
 import numpy as np
-from six.moves import xrange
+from six.moves import xrange, zip
 import time
 
 __author__ = 'peter'
@@ -188,7 +188,7 @@ def zip_minibatch_iterate_info(arrays, minibatch_size, n_epochs=None, test_epoch
     if n_epochs is None:
         assert isinstance(test_epochs, (list, tuple, np.ndarray)), "If you don't specify n_epochs, you need to specify an array of test epochs."
         n_epochs = test_epochs[-1]
-    for arrays, info in itertools.izip(
+    for arrays, info in zip(
             zip_minibatch_iterate(arrays, minibatch_size=minibatch_size, n_epochs='inf'),
             iteration_info(n_samples=arrays[0].shape[0], minibatch_size=minibatch_size, test_epochs=test_epochs, n_epochs=n_epochs)
             ):
@@ -198,7 +198,7 @@ def zip_minibatch_iterate_info(arrays, minibatch_size, n_epochs=None, test_epoch
 
 
 def minibatch_index_info_generator(n_samples, minibatch_size, n_epochs, test_epochs = None, slice_when_possible=False):
-    for ixs, info in itertools.izip(
+    for ixs, info in zip(
             minibatch_index_generator(n_samples=n_samples, minibatch_size=minibatch_size, n_epochs=n_epochs, slice_when_possible=slice_when_possible),
             iteration_info(n_samples=n_samples, minibatch_size=minibatch_size, test_epochs=test_epochs, n_epochs=n_epochs)
             ):
@@ -233,7 +233,7 @@ def minibatch_iterate_info(data, minibatch_size, n_epochs, test_epochs = None):
         minibatch is a minibatch of data (minibatch_size, ...)
         info is an IterationInfo object returning information about the state of iteration.
     """
-    for arrays, info in itertools.izip(
+    for arrays, info in zip(
             minibatch_iterate(data, minibatch_size=minibatch_size, n_epochs=n_epochs),
             iteration_info(n_samples=data.shape[0], minibatch_size=minibatch_size, test_epochs=test_epochs)
             ):
@@ -253,7 +253,7 @@ def minibatch_process(f, minibatch_size, mb_args = (), mb_kwargs = {}, fixed_kwa
     :param fixed_kwargs: Keyword arguments that will remain fixed.
     :return: The output y
     """
-    all_mb_args = list(mb_args) + mb_kwargs.values()
+    all_mb_args = list(mb_args) + list(mb_kwargs.values())
     assert len(all_mb_args)>0, 'Need some input.'
     assert callable(f), 'f must be a function'
     n_samples = len(mb_args[0])
@@ -261,7 +261,7 @@ def minibatch_process(f, minibatch_size, mb_args = (), mb_kwargs = {}, fixed_kwa
     mb_kwarg_list = mb_kwargs.items()
     fixed_kwarg_list = fixed_kwargs.items()
     index_generator = minibatch_index_generator(n_samples = n_samples, n_epochs=1, minibatch_size=minibatch_size, final_treatment='truncate')
-    ix = index_generator.next()
+    ix = next(index_generator)
     first_output = f(*(a[ix] for a in mb_args), **dict([(k, v[ix]) for k, v in mb_kwarg_list]+fixed_kwarg_list))
     output_shape = first_output.shape if minibatch_size==SINGLE_MINIBATCH_SIZE else first_output.shape[1:]
     results = np.empty((n_samples, )+output_shape, dtype=first_output.dtype)

--- a/artemis/ml/tools/iteration.py
+++ b/artemis/ml/tools/iteration.py
@@ -77,7 +77,7 @@ def checkpoint_minibatch_index_generator(n_samples, checkpoints, slice_when_poss
     """
     checkpoints = np.array(checkpoints, dtype = int)
     assert len(checkpoints) > 1 and checkpoints[0] >= 0 and np.all(np.diff(checkpoints) > 0)
-    checkpoint_divs = zip(checkpoints[:-1], checkpoints[1:])
+    checkpoint_divs = list(zip(checkpoints[:-1], checkpoints[1:]))
     if checkpoints[0] > 0:
         checkpoint_divs.insert(0, (0, checkpoints[0]))
     for start, stop in checkpoint_divs:

--- a/artemis/ml/tools/iteration.py
+++ b/artemis/ml/tools/iteration.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 import itertools
 from artemis.general.should_be_builtins import bad_value
 import numpy as np
+from six.moves import xrange
 import time
 
 __author__ = 'peter'

--- a/artemis/ml/tools/iteration.py
+++ b/artemis/ml/tools/iteration.py
@@ -1,5 +1,8 @@
 from collections import namedtuple
 import itertools
+
+from six import string_types
+
 from artemis.general.should_be_builtins import bad_value
 import numpy as np
 from six.moves import xrange
@@ -153,7 +156,7 @@ def iteration_info(n_samples, minibatch_size, test_epochs = None, n_epochs = 5):
                 False if test_epochs=='never' else
                 np.floor(epoch)>np.floor(last_epoch) if test_epochs == 'every' else
                 bad_value(test_epochs)
-            ) if isinstance(test_epochs, basestring) else \
+            ) if isinstance(test_epochs, string_types) else \
             np.floor(epoch/period) > np.floor(last_epoch/period) if isinstance(test_epochs, tuple) else \
             False if test_epochs is None else \
             np.searchsorted(test_epochs, epoch, side='right') > np.searchsorted(test_epochs, last_epoch, side='right')

--- a/artemis/ml/tools/iteration.py
+++ b/artemis/ml/tools/iteration.py
@@ -259,7 +259,7 @@ def minibatch_process(f, minibatch_size, mb_args = (), mb_kwargs = {}, fixed_kwa
     n_samples = len(mb_args[0])
     assert all(len(arg) == n_samples for arg in all_mb_args)
     mb_kwarg_list = mb_kwargs.items()
-    fixed_kwarg_list = fixed_kwargs.items()
+    fixed_kwarg_list = list(fixed_kwargs.items())
     index_generator = minibatch_index_generator(n_samples = n_samples, n_epochs=1, minibatch_size=minibatch_size, final_treatment='truncate')
     ix = next(index_generator)
     first_output = f(*(a[ix] for a in mb_args), **dict([(k, v[ix]) for k, v in mb_kwarg_list]+fixed_kwarg_list))

--- a/artemis/ml/tools/processors.py
+++ b/artemis/ml/tools/processors.py
@@ -145,11 +145,11 @@ def single_to_batch(fcn, *batch_inputs, **batch_kwargs):
     """
     n_samples = len(batch_inputs[0])
     assert all(len(b) == n_samples for b in batch_inputs)
-    first_out = fcn(*[b[0] for b in batch_inputs], **{k: b[0] for k, b in batch_kwargs.iteritems()})
+    first_out = fcn(*[b[0] for b in batch_inputs], **{k: b[0] for k, b in batch_kwargs.items()})
     if n_samples==1:
         return first_out[None]
     out = np.empty((n_samples, )+first_out.shape)
     out[0] = n_samples
     for i in xrange(1, n_samples):
-        out[i] = fcn(*[b[i] for b in batch_inputs], **{k: b[i] for k, b in batch_kwargs.iteritems()})
+        out[i] = fcn(*[b[i] for b in batch_inputs], **{k: b[i] for k, b in batch_kwargs.items()})
     return out

--- a/artemis/ml/tools/processors.py
+++ b/artemis/ml/tools/processors.py
@@ -1,5 +1,6 @@
 from abc import abstractmethod
 import numpy as np
+from six.moves import xrange
 
 __author__ = 'peter'
 

--- a/artemis/ml/tools/test_iteration.py
+++ b/artemis/ml/tools/test_iteration.py
@@ -38,12 +38,12 @@ def test_checkpoint_minibatch_generator():
     for checkpoints in ([0, 20, 30, 63, 100], [20, 30, 63, 100]):
         for slice_when_possible in (True, False):
             iterator = checkpoint_minibatch_index_generator(n_samples=n_samples, checkpoints=checkpoints, slice_when_possible=slice_when_possible)
-            assert np.array_equal(data[iterator.next()], np.arange(20))
-            assert np.array_equal(data[iterator.next()], np.arange(20, 30))
-            assert np.array_equal(data[iterator.next()], np.arange(30, 63) % 48)
-            assert np.array_equal(data[iterator.next()], np.arange(63, 100) % 48)
+            assert np.array_equal(data[next(iterator)], np.arange(20))
+            assert np.array_equal(data[next(iterator)], np.arange(20, 30))
+            assert np.array_equal(data[next(iterator)], np.arange(30, 63) % 48)
+            assert np.array_equal(data[next(iterator)], np.arange(63, 100) % 48)
             try:
-                iterator.next()
+                next(iterator)
             except StopIteration:
                 pass
             except:

--- a/artemis/ml/tools/test_processors.py
+++ b/artemis/ml/tools/test_processors.py
@@ -1,4 +1,5 @@
 import numpy as np
+from six.moves import xrange
 
 from artemis.ml.tools.processors import RunningAverage
 

--- a/artemis/plotting/data_conversion.py
+++ b/artemis/plotting/data_conversion.py
@@ -1,7 +1,6 @@
 from artemis.general.should_be_builtins import memoize
 import numpy as np
-
-
+from six.moves import xrange
 
 
 __author__ = 'peter'

--- a/artemis/plotting/db_plotting.py
+++ b/artemis/plotting/db_plotting.py
@@ -197,7 +197,7 @@ def reset_dbplot():
     if is_server_plotting_on():
         deconstruct_plotting_server()
     else:
-        for fig_name, plot_window in _DBPLOT_FIGURES.items():
+        for fig_name, plot_window in list(_DBPLOT_FIGURES.items()):
             plt.close(plot_window.figure)
             del _DBPLOT_FIGURES[fig_name]
 

--- a/artemis/plotting/db_plotting.py
+++ b/artemis/plotting/db_plotting.py
@@ -155,7 +155,7 @@ def dbplot(data, name = None, plot_type = None, axis=None, plot_mode = 'live', d
 
     if cornertext is not None:
         if not hasattr(_DBPLOT_FIGURES[fig].figure, '__cornertext'):
-            _DBPLOT_FIGURES[fig].figure.__cornertext = _DBPLOT_FIGURES[fig].subplots.values()[0].axis.annotate(cornertext, xy=(0, 0), xytext=(0.01, 0.98), textcoords='figure fraction')
+            _DBPLOT_FIGURES[fig].figure.__cornertext = next(iter(_DBPLOT_FIGURES[fig].subplots.values())).axis.annotate(cornertext, xy=(0, 0), xytext=(0.01, 0.98), textcoords='figure fraction')
         else:
             _DBPLOT_FIGURES[fig].figure.__cornertext.set_text(cornertext)
     if title is not None:

--- a/artemis/plotting/db_plotting.py
+++ b/artemis/plotting/db_plotting.py
@@ -1,4 +1,7 @@
 from collections import OrderedDict, namedtuple
+
+from six import string_types
+
 from artemis.config import get_artemis_config_value
 from artemis.plotting.matplotlib_backend import BarPlot
 from matplotlib.axes import Axes
@@ -121,7 +124,7 @@ def dbplot(data, name = None, plot_type = None, axis=None, plot_mode = 'live', d
         if isinstance(axis, Axes):
             ax = axis
             ax_name = str(axis)
-        elif isinstance(axis, basestring) or axis is None:
+        elif isinstance(axis, string_types) or axis is None:
             ax = select_subplot(axis, fig=_DBPLOT_FIGURES[fig].figure, layout=_default_layout if layout is None else layout)
             ax_name = axis
             # ax.set_title(axis)

--- a/artemis/plotting/demo_dbplot.py
+++ b/artemis/plotting/demo_dbplot.py
@@ -3,6 +3,7 @@ from functools import partial
 from artemis.plotting.db_plotting import dbplot, hold_dbplots, set_dbplot_figure_size
 import numpy as np
 from artemis.plotting.matplotlib_backend import MovingPointPlot
+from six.moves import xrange
 import time
 
 __author__ = 'peter'

--- a/artemis/plotting/demo_dbplot.py
+++ b/artemis/plotting/demo_dbplot.py
@@ -3,7 +3,7 @@ from functools import partial
 from artemis.plotting.db_plotting import dbplot, hold_dbplots, set_dbplot_figure_size
 import numpy as np
 from artemis.plotting.matplotlib_backend import MovingPointPlot
-from six.moves import xrange
+from six.moves import input, xrange
 import time
 
 __author__ = 'peter'
@@ -64,4 +64,4 @@ if __name__ == '__main__':
     demo_dbplot()
     # demo_debug_dbplot()
     print(("#"*40))
-    raw_input("Terminate")
+    input("Terminate")

--- a/artemis/plotting/easy_plotting.py
+++ b/artemis/plotting/easy_plotting.py
@@ -33,7 +33,7 @@ def plot_data_dict(data_dict, plots = None, mode = 'static', hang = True, figure
         data_dict = OrderedDict(data_dict)
 
     if plots is None:
-        plots = {k: get_plot_from_data(v, mode = mode, **plot_preference_kwargs) for k, v in data_dict.iteritems()}
+        plots = {k: get_plot_from_data(v, mode = mode, **plot_preference_kwargs) for k, v in data_dict.items()}
 
     if figure is None:
         if size is not None:
@@ -41,7 +41,7 @@ def plot_data_dict(data_dict, plots = None, mode = 'static', hang = True, figure
             rcParams['figure.figsize'] = size
         figure = plt.figure()
     n_rows, n_cols = vector_length_to_tile_dims(len(data_dict))
-    for i, (k, v) in enumerate(data_dict.iteritems()):
+    for i, (k, v) in enumerate(data_dict.items()):
         plt.subplot(n_rows, n_cols, i + 1)
         plots[k].update(v)
         plots[k].plot()

--- a/artemis/plotting/expanding_subplots.py
+++ b/artemis/plotting/expanding_subplots.py
@@ -93,7 +93,7 @@ def select_subplot(name, fig=None, layout=None, **subplot_args):
         plt.subplot(_subplots[name])
     else:
         if name is None:
-            name = _plot_name_generator.next()
+            name = next(_plot_name_generator)
         _subplots[name] = _create_subplot(fig=fig, layout=layout, **subplot_args)
     return _subplots[name]
 
@@ -127,7 +127,7 @@ class CaptureNewSubplots(object):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.new_subplots = OrderedDict((s, p) for s, p in _subplots.iteritems() if s not in self._old_subplots)
+        self.new_subplots = OrderedDict((s, p) for s, p in _subplots.items() if s not in self._old_subplots)
 
     def get_new_subplots(self):
         return self.new_subplots

--- a/artemis/plotting/live_plotting.py
+++ b/artemis/plotting/live_plotting.py
@@ -44,7 +44,7 @@ class BaseStream(object):
             plot_data_dict(data_dict, plots = self._plots, hang = False, figure = self._fig)
         else:
             if name is None:  # Update all plots
-                for k, v in data_dict.iteritems():
+                for k, v in data_dict.items():
                     self._plots[k].update(v)
                     self._plots[k].plot()
             else:
@@ -106,7 +106,7 @@ class LiveStream(BaseStream):
 
     def _get_plots_from_first_data(self, first_data):
         return {k: get_plot_from_data(v, mode = self._plot_mode, **self._plot_preference_kwargs)
-            if k not in self._plot_types else self._plot_types[k] for k, v in first_data.iteritems()}
+            if k not in self._plot_types else self._plot_types[k] for k, v in first_data.items()}
 
 
 LivePlot = namedtuple('PlotBuilder', ['plot', 'cb'])
@@ -126,12 +126,12 @@ class LiveCanal(BaseStream):
         :param kwargs: Passed up to BaseStream
         """
         self._live_plots = live_plots
-        self._callbacks = {k: lp.cb if isinstance(lp, LivePlot) else lp for k, lp in live_plots.iteritems()}
+        self._callbacks = {k: lp.cb if isinstance(lp, LivePlot) else lp for k, lp in live_plots.items()}
         BaseStream.__init__(self, **kwargs)
 
     def _get_data_structure(self):
-        return {k: cb() for k, cb in self._callbacks.iteritems()}
+        return {k: cb() for k, cb in self._callbacks.items()}
 
     def _get_plots_from_first_data(self, first_data):
         # first_data = dict(first_data)
-        return {k: pb.plot if isinstance(pb, LivePlot) else get_plot_from_data(first_data[k], mode = 'live') for k, pb in self._live_plots.iteritems()}
+        return {k: pb.plot if isinstance(pb, LivePlot) else get_plot_from_data(first_data[k], mode = 'live') for k, pb in self._live_plots.items()}

--- a/artemis/plotting/matplotlib_backend.py
+++ b/artemis/plotting/matplotlib_backend.py
@@ -1,6 +1,8 @@
 from abc import ABCMeta, abstractmethod
 from itertools import cycle
 
+from six import string_types
+
 from artemis.config import get_artemis_config_value
 from artemis.general.should_be_builtins import bad_value
 from artemis.plotting.data_conversion import (put_data_in_grid, RecordBuffer, data_to_image, put_list_of_images_in_array,
@@ -355,7 +357,7 @@ class TextPlot(IPlot):
         self._y_offset = {'bottom': 0.05, 'center': 0.5, 'top': 0.95}[self.vertical_alignment]
 
     def update(self, string):
-        if not isinstance(string, basestring):
+        if not isinstance(string, string_types):
             string = str(string)
         history = self._buffer(string)
         self._full_text = '\n'.join(history)
@@ -468,7 +470,7 @@ def get_live_plot_from_data(data, line_to_image_threshold = 8, cmap = 'gray'):
 
     # TODO: Maybe refactor that so that plot objects contain their own "data validation" code, and we can
     # simply ask plots in sequence whether they can handle the data.
-    if isinstance(data, basestring):
+    if isinstance(data, string_types):
         return TextPlot()
 
     if isinstance(data, list):
@@ -513,7 +515,7 @@ def get_live_plot_from_data(data, line_to_image_threshold = 8, cmap = 'gray'):
 
 def get_static_plot_from_data(data, line_to_image_threshold=8, cmap = 'gray'):
 
-    if isinstance(data, basestring):
+    if isinstance(data, string_types):
         return TextPlot()
 
     is_scalar = np.isscalar(data) or data.shape == ()

--- a/artemis/plotting/matplotlib_backend.py
+++ b/artemis/plotting/matplotlib_backend.py
@@ -163,7 +163,7 @@ class LinePlot(HistoryFreePlot):
         self.axes_update_mode = axes_update_mode
         self.add_end_markers = add_end_markers
         self._end_markers = []
-        self.legend_entries = [legend_entries] if isinstance(legend_entries, basestring) else legend_entries
+        self.legend_entries = [legend_entries] if isinstance(legend_entries, string_types) else legend_entries
         self.legend_entry_size = legend_entry_size
         self.allow_axis_offset = allow_axis_offset
 

--- a/artemis/plotting/matplotlib_backend.py
+++ b/artemis/plotting/matplotlib_backend.py
@@ -7,6 +7,7 @@ from artemis.plotting.data_conversion import (put_data_in_grid, RecordBuffer, da
     UnlimitedRecordBuffer)
 from matplotlib import pyplot as plt
 import numpy as np
+from six.moves import xrange
 
 
 __author__ = 'peter'

--- a/artemis/plotting/saving_plots.py
+++ b/artemis/plotting/saving_plots.py
@@ -37,7 +37,7 @@ def save_figure(fig, path, ext=None, default_ext = '.pdf'):
 
     make_file_dir(path)
     if ext=='.pkl':
-        with open(path, 'w') as f:
+        with open(path, 'wb') as f:
             pickle.dump(fig, f, protocol=pickle.HIGHEST_PROTOCOL)
     else:
         fig.savefig(path)

--- a/artemis/plotting/test_animation.py
+++ b/artemis/plotting/test_animation.py
@@ -3,6 +3,8 @@ import pytest
 matplotlib.use('TkAgg')
 import matplotlib.pyplot as plt
 import numpy as np
+from six.moves import xrange
+
 __author__ = 'peter'
 
 """

--- a/artemis/plotting/test_db_plotting.py
+++ b/artemis/plotting/test_db_plotting.py
@@ -9,6 +9,7 @@ from artemis.plotting.matplotlib_backend import LinePlot, HistogramPlot, MovingP
 import pytest
 from matplotlib import pyplot as plt
 from matplotlib import gridspec
+from six.moves import xrange
 
 __author__ = 'peter'
 

--- a/artemis/plotting/test_live_plotting.py
+++ b/artemis/plotting/test_live_plotting.py
@@ -2,6 +2,7 @@ import time
 from artemis.plotting.live_plotting import LiveStream, LivePlot, LiveCanal
 from artemis.plotting.matplotlib_backend import MovingImagePlot, MovingPointPlot, LinePlot, ImagePlot, HistogramPlot
 from itertools import count
+from six.moves import xrange
 
 __author__ = 'peter'
 import numpy as np

--- a/artemis/plotting/test_live_plotting.py
+++ b/artemis/plotting/test_live_plotting.py
@@ -13,7 +13,7 @@ def test_streaming(duration = 10):
     c = count()
 
     stream = LiveStream(lambda: {
-        'text': ['Veni', 'Vidi', 'Vici'][c.next() % 3],
+        'text': ['Veni', 'Vidi', 'Vici'][next(c) % 3],
         'images': {
             'bw_image': np.random.randn(20, 20),
             'col_image': np.random.randn(20, 20, 3),
@@ -65,7 +65,7 @@ def test_canaling(duration = 10):
     # that spits out the same data when called in sequence.
     cb_constructor_1d = lambda: lambda rng = np.random.RandomState(0): rng.randn(n_dims)
     cb_image_data = lambda: lambda rng = np.random.RandomState(1): rng.rand(20, 30)
-    cb_sinusoid_data = lambda: lambda c=count(): np.sin(c.next()/40.)
+    cb_sinusoid_data = lambda: lambda c=count(): np.sin(next(c)/40.)
 
     canal = LiveCanal({
         'histo-mass': LivePlot(plot = HistogramPlot([-2.5, 0, 0.5, 1, 1.5, 2, 2.5], mode = 'mass'), cb = lambda: np.random.randn(np.random.randint(10))),

--- a/artemis/plotting/test_web_backend.py
+++ b/artemis/plotting/test_web_backend.py
@@ -4,6 +4,7 @@ from artemis.plotting.db_plotting import dbplot
 from artemis.plotting.web_backend import setup_web_plotting
 import numpy as np
 from matplotlib import pyplot as plt
+from six.moves import xrange
 
 
 __author__ = 'peter'

--- a/artemis/plotting/web_backend.py
+++ b/artemis/plotting/web_backend.py
@@ -1,6 +1,6 @@
 from tempfile import gettempdir
 import time
-import thread
+from six.moves import _thread as thread
 import SimpleHTTPServer
 import SocketServer
 

--- a/artemis/plotting/web_backend.py
+++ b/artemis/plotting/web_backend.py
@@ -1,9 +1,8 @@
 from tempfile import gettempdir
 import time
 from six.moves import _thread as thread
-import SimpleHTTPServer
+from six.moves import SimpleHTTPServer
 import SocketServer
-
 from artemis.fileman.local_dir import get_artemis_data_path
 from artemis.plotting.manage_plotting import set_show_callback, set_draw_callback
 import os

--- a/artemis/plotting/web_backend.py
+++ b/artemis/plotting/web_backend.py
@@ -1,8 +1,7 @@
 from tempfile import gettempdir
 import time
 from six.moves import _thread as thread
-from six.moves import SimpleHTTPServer
-import SocketServer
+from six.moves import SimpleHTTPServer, socketserver
 from artemis.fileman.local_dir import get_artemis_data_path
 from artemis.plotting.manage_plotting import set_show_callback, set_draw_callback
 import os
@@ -48,11 +47,11 @@ def _launch_on_first_available_port(first_port):
     port = first_port
     while True:
         try:
-            httpd = SocketServer.TCPServer(('', port), Handler)
+            httpd = socketserver.TCPServer(('', port), Handler)
             # print 'Serving on port', port
             ARTEMIS_LOGGER.warn("Serving Plots at http://localhost:%s" % (port, ))
             httpd.serve_forever()
-        except SocketServer.socket.error as exc:
+        except socketserver.socket.error as exc:
             if exc.args[0] == 48 or exc.args[0] == 98:
                 ARTEMIS_LOGGER.info('Port', port, 'already in use')
                 port += 1

--- a/artemis/remote/child_processes.py
+++ b/artemis/remote/child_processes.py
@@ -15,6 +15,8 @@ import pickle
 
 import StringIO
 
+from six import string_types
+
 from artemis.general.should_be_builtins import file_path_to_absolute_module
 from artemis.remote import remote_function_run_script
 from artemis.remote.plotting.utils import handle_socket_accepts
@@ -148,7 +150,7 @@ class ChildProcess(object):
         if self.local_process:
             if type(command) == list:
                 sub = subprocess.Popen(command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            elif type(command) == str or type(command) == unicode:
+            elif isinstance(command, string_types):
                 shlexed_command = shlex.split(command)
                 sub = subprocess.Popen(shlexed_command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             else:
@@ -254,7 +256,7 @@ class PythonChildProcess(ChildProcess):
                 command = [c.replace("python", sys.executable, 1) if c.startswith("python") else c for c in command]
                 command = [s.replace("~",home_dir) for s in command]
 
-        elif type(command) == str or type(command) == unicode and command.startswith("python"):
+        elif isinstance(command, string_types) and command.startswith("python"):
             if self.set_up_port_for_structured_back_communication:
                 command += " --port=%i "%port
                 command += "--address=%s"%address

--- a/artemis/remote/nanny.py
+++ b/artemis/remote/nanny.py
@@ -71,7 +71,7 @@ class Nanny(object):
         self.managed_child_processes[cp.get_id()] = ManagedChildProcess(cp, monitor_for_termination,monitor_if_stuck_timeout)
 
     def get_child_processes(self):
-        return {id:mcp.get_process() for id,mcp in self.managed_child_processes.iteritems()}
+        return {id:mcp.get_process() for id,mcp in self.managed_child_processes.items()}
 
     def execute_all_child_processes(self, time_out=1, stdout_stopping_criterium=lambda line:False, stderr_stopping_criterium =lambda line:False, blocking=True):
         '''
@@ -137,11 +137,11 @@ class Nanny(object):
 
         # Grace period for other threads to shutdown
         time.sleep(time_out)
-        for id,cp in self.managed_child_processes.iteritems():
+        for id,cp in self.managed_child_processes.items():
             if cp.is_alive():
                 print(("Child Process %s at %s did not terminate %s seconds after the first process in cluster terminated. Terminating now." %(cp.get_name(), cp.get_ip(), time_out)))
                 cp.deconstruct()
-        for id,cp in self.managed_child_processes.iteritems():
+        for id,cp in self.managed_child_processes.items():
             if cp.is_alive():
                 print(("Child Process %s at %s did not terminate. Force quitting now." %(cp.get_name(),cp.get_ip())))
                 cp.deconstruct(signal.SIGKILL)

--- a/artemis/remote/utils.py
+++ b/artemis/remote/utils.py
@@ -8,6 +8,7 @@ import sys
 
 import os
 import paramiko
+from six.moves import input
 
 from artemis.config import get_artemis_config_value
 
@@ -22,20 +23,17 @@ def one_time_send_to(address, port, message):
     :param message: A string to send
     '''
 
-    if isinstance(port, basestring):
-        port = int(port)
-
-    server_address = (address, port)
+    server_address = (address, int(port))
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     try:
         sock.connect(tuple(server_address))
     except:
         raise
 
-    send_size(sock,message)
+    send_size(sock, message)
 
 
-def get_socket(address,port):
+def get_socket(address, port):
     '''
     Returns a socket, bound to the next free port starting from the given port.
     :param port:
@@ -137,7 +135,7 @@ def get_remote_artemis_path(remote_ip):
     return get_artemis_config_value(
         section=remote_ip,
         option='artemis_path',
-        default_generator=lambda: raw_input('Specify Remote Artemis Installation Path: '),
+        default_generator=lambda: input('Specify Remote Artemis Installation Path: ').strip(),
         write_default=True
         )
 

--- a/artemis/remote/virtualenv.py
+++ b/artemis/remote/virtualenv.py
@@ -50,7 +50,7 @@ def install_packages_on_remote_virtualenv(ip_address, packages):
     activate_path = os.path.join(os.path.dirname(python_path),"activate") # TODO: Make this work without the user using virtualenv
     activate_command = "source %s"%activate_path
     ssh_conn = get_ssh_connection(ip_address)
-    for key,version in packages.iteritems():
+    for key,version in packages.items():
         install_command = "pip install -U %s==%s" %(key,version)
         function = "; ".join([activate_command, install_command])
         stdin , stdout, stderr =ssh_conn.exec_command(function)
@@ -87,7 +87,7 @@ def check_diff_local_remote_virtualenv(ip_address, auto_install=None, auto_upgra
     local_packages = {i.key: i.version  for i in pip.get_installed_distributions(include_editables=False)}
     missing_packages = OrderedDict()
     different_versions = OrderedDict()
-    for (local_key, local_version) in local_packages.iteritems():
+    for (local_key, local_version) in local_packages.items():
         if local_key not in remote_packages.keys():
             missing_packages[local_key] = local_version
         elif local_version != remote_packages[local_key]:
@@ -135,12 +135,12 @@ def check_diff_local_remote_virtualenv(ip_address, auto_install=None, auto_upgra
     if len(different_versions) > 0:
         if auto_upgrade is not None:
             if auto_upgrade:
-                for key, versions in different_versions.iteritems():
+                for key, versions in different_versions.items():
                     chosen_packages_to_install_and_update[key] = versions[0]
             else:
                 print(("Some locally installed packages are installed in a different version than on the remote virtualenv at %s. You chose not to upgrade them. "
                   "The different packages are:" % (ip_address)))
-                for key, versions in different_versions.iteritems():
+                for key, versions in different_versions.items():
                     print(("%s: local %s, reote %s") % (key, versions[0],versions[1]))
         else:
             print("The following locally installed packages are installed in a different version than on the virtualenv at %s:" % ip_address)
@@ -151,7 +151,7 @@ def check_diff_local_remote_virtualenv(ip_address, auto_install=None, auto_upgra
                 ix=ix.strip(",")
                 numbers = ix.split(",")
                 if numbers[0] == "all" and len(numbers) == 1:
-                    for key, versions in different_versions.iteritems():
+                    for key, versions in different_versions.items():
                         chosen_packages_to_install_and_update[key] = versions[0]
                     valid = True
                 elif not numbers[0] and len(numbers) == 1:
@@ -178,7 +178,7 @@ def check_diff_local_remote_virtualenv(ip_address, auto_install=None, auto_upgra
                 remote_packages = get_remote_installed_packages(ip_address)
                 missing_packages = OrderedDict()
                 different_versions = OrderedDict()
-                for (local_key, local_version) in local_packages.iteritems():
+                for (local_key, local_version) in local_packages.items():
                     if local_key not in remote_packages.keys():
                         missing_packages[local_key] = local_version
                     elif local_version != remote_packages[local_key]:

--- a/artemis/remote/virtualenv.py
+++ b/artemis/remote/virtualenv.py
@@ -4,6 +4,8 @@ import sys
 from collections import OrderedDict
 import numpy as np
 import pip
+from six.moves import input
+
 from artemis.fileman.config_files import get_config_value
 from artemis.config import get_artemis_config_value
 from artemis.remote.utils import get_ssh_connection
@@ -107,7 +109,7 @@ def check_diff_local_remote_virtualenv(ip_address, auto_install=None, auto_upgra
             print('\n'.join(['%s: %s (%s)' % (i, key, missing_packages[key]) for i, key in enumerate(missing_packages.keys())]))
             valid = False
             while not valid:
-                ix = raw_input("Please specify in the format '1, 3, 4' all packages you want to install. Can be empty or 'all' ")
+                ix = input("Please specify in the format '1, 3, 4' all packages you want to install. Can be empty or 'all' ")
                 ix=ix.strip(",")
                 numbers = ix.split(",")
                 if numbers[0] == "all" and len(numbers) == 1:
@@ -145,7 +147,7 @@ def check_diff_local_remote_virtualenv(ip_address, auto_install=None, auto_upgra
             print('\n'.join(['%s: %s (local: %s) => (remote: %s)' % (i, key, different_versions[key][0], different_versions[key][1]) for i, key in enumerate(different_versions.keys())]))
             valid = False
             while not valid:
-                ix = raw_input("Please specify in the format '1, 3, 4' all remote packages you want to upgrade (downgrade) to the local version. Can be empty or 'all' ")
+                ix = input("Please specify in the format '1, 3, 4' all remote packages you want to upgrade (downgrade) to the local version. Can be empty or 'all' ")
                 ix=ix.strip(",")
                 numbers = ix.split(",")
                 if numbers[0] == "all" and len(numbers) == 1:
@@ -184,8 +186,9 @@ def check_diff_local_remote_virtualenv(ip_address, auto_install=None, auto_upgra
                 if len(missing_packages)>0 or len(different_versions)>0:
                     valid = False
                     while not valid:
-                        ix=raw_input("The following packages could not be installed or upgraded: \n %s \nDo you want to continue? (y/n)"% (",".join(missing_packages.keys() + different_versions.keys())))
-                        if ix in ["y","n"]:
+                        ix=input("The following packages could not be installed or upgraded: \n %s \nDo you want to continue? (y/n)"% (",".join(missing_packages.keys() + different_versions.keys())))
+                        ix=ix.strip().lower()
+                        if ix in ("y", "n"):
                             valid=True
 
                     if ix == "n":
@@ -193,4 +196,5 @@ def check_diff_local_remote_virtualenv(ip_address, auto_install=None, auto_upgra
                         sys.exit(0)
                     else:
                         print("Ignoring discrepancies...")
+    
     print(("="*10 + " Done remote virtualenv %s "%ip_address + "="*10))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+six
 numpy
 scipy
 matplotlib


### PR DESCRIPTION
__Ready for review.__

https://pythonhosted.org/six will be our Python 2 / 3 compatibility module.

Also removed backslashs (\\) to avoid the problem when a whitespace character is placed to the right of the backslash:  Your script breaks but the reader can not see why it is broken.
* https://www.python.org/dev/peps/pep-0008/#id19
* https://www.python.org/dev/peps/pep-0008/#id28

On raw_input() --> input():
* Use `input().strip()` to remove leading or trailing whitespace.
* Use `input.strip().lower()` when looking for specific text to be kind to users with capslock on